### PR TITLE
Add Embedding+Tabular v2-lite dataset, model, loss and evaluation support

### DIFF
--- a/Finetuning/dataloader.py
+++ b/Finetuning/dataloader.py
@@ -1277,6 +1277,12 @@ class advCheX_hyp_grade_stage_embtab_base(Dataset):
         return len(self.img_list)
 
 
+class advCheX_hyp_grade_stage_embtab_v2lite(advCheX_hyp_grade_stage_embtab_base):
+    """Embedding + tabular v2-lite dataset: reuse embtab-base loading and tab normalization."""
+
+    pass
+
+
 class advCheX_hyp_grade_stage_v2(advCheX_hyp_multi_grade_stage_v1):
     """v2 数据集薄包装：复用 v1 的 CSV 读取与监督结构。"""
 

--- a/Finetuning/engine.py
+++ b/Finetuning/engine.py
@@ -345,6 +345,32 @@ class MultiHeadOrdinalLoss(torch.nn.Module):
             'pS_fused3': pS_fused,
         }
 
+    def _v2lite_joint_from_outputs(self, outputs, eps=1e-8):
+        ge_g = corn_marginal_ge_probs(torch.sigmoid(outputs['grade_logits']))
+        ge_s = corn_marginal_ge_probs(torch.sigmoid(outputs['stage_ind_logits']))
+        pG = self._build_full_grade_probs_from_ge(ge_g)
+        pS = self._build_full_stage_probs_from_ge(ge_s)
+        q1 = torch.sigmoid(outputs['q1_logit'].view(-1))
+        q2 = torch.sigmoid(outputs['q2_logit'].view(-1))
+        beta = float(getattr(self, 'joint_beta_stage', 0.5))
+        gamma = float(getattr(self, 'joint_gamma_cond', 0.5))
+        pg = pG.clamp(eps, 1.0)
+        ps = pS.clamp(eps, 1.0)
+        q1c = q1.clamp(eps, 1.0 - eps)
+        q2c = q2.clamp(eps, 1.0 - eps)
+        joint_logits = torch.stack([
+            torch.log(pg[:, 0]) + beta * torch.log(ps[:, 0]),
+            torch.log(pg[:, 1]) + beta * torch.log(ps[:, 1]) + gamma * torch.log(q1c),
+            torch.log(pg[:, 1]) + beta * torch.log(ps[:, 2]) + gamma * torch.log(1.0 - q1c),
+            torch.log(pg[:, 2]) + beta * torch.log(ps[:, 1]) + gamma * torch.log(q2c),
+            torch.log(pg[:, 2]) + beta * torch.log(ps[:, 2]) + gamma * torch.log(1.0 - q2c),
+            torch.log(pg[:, 3]) + beta * torch.log(ps[:, 2]),
+        ], dim=1)
+        P_joint6 = torch.softmax(joint_logits, dim=1)
+        pG_fused = torch.stack([P_joint6[:, 0], P_joint6[:, 1] + P_joint6[:, 2], P_joint6[:, 3] + P_joint6[:, 4], P_joint6[:, 5]], dim=1)
+        pS_fused = torch.stack([P_joint6[:, 0], P_joint6[:, 1] + P_joint6[:, 3], P_joint6[:, 2] + P_joint6[:, 4] + P_joint6[:, 5]], dim=1)
+        return {'pG_raw4': pG, 'pS_ind3': pS, 'q1': q1, 'q2': q2, 'joint_logits': joint_logits, 'P_joint6': P_joint6, 'pG_fused4': pG_fused, 'pS_fused3': pS_fused}
+
     def set_epoch(self, epoch):
         self.current_epoch = epoch
 
@@ -466,7 +492,8 @@ class MultiHeadOrdinalLoss(torch.nn.Module):
                 raw_grade = torch.sum(y_grade > 0.5, dim=1).long()
             if raw_stage is None:
                 raw_stage = torch.sum(y_stage > 0.5, dim=1).long()
-            fused = self._v2_joint_from_outputs(outputs)
+            is_v2lite = str(getattr(self, "data_set", "")).lower() == "advchex_hyp_grade_stage_embtab_v2lite"
+            fused = self._v2lite_joint_from_outputs(outputs) if is_v2lite else self._v2_joint_from_outputs(outputs)
             loss_grade_base = self._corn_task_loss(outputs['grade_logits'], y_grade, pos_weight=self.loss_grade.pos_weight)
             loss_grade_soft = loss_grade_base.new_tensor(0.0)
             if str(getattr(self, 'v1_soft_label_mode', 'none') or 'none').lower() == 'full':
@@ -495,13 +522,19 @@ class MultiHeadOrdinalLoss(torch.nn.Module):
 
             D = self._graph_distance_matrix(fused['P_joint6'].device)
             tau = float(getattr(self, 'joint_graph_tau', 0.7))
-            soft_targets = torch.softmax(-D[targets['joint_id'].long()] / max(tau, 1e-6), dim=1)
-            loss_soft_joint = (-(soft_targets * torch.log(fused['P_joint6'].clamp_min(1e-8))).sum(dim=1)).mean()
-            expected_cost = (fused['P_joint6'] * D[targets['joint_id'].long()]).sum(dim=1).mean()
-            lambda_soft_joint_eff = float(getattr(self, 'lambda_soft_joint', 0.15) or 0.0) * self._v2_soft_joint_factor()
-            if getattr(self, 'lpv3_active', False) and self.current_epoch < int(getattr(self, 'lpv3_enable_soft_joint_after_epoch', 10) or 10):
-                lambda_soft_joint_eff = 0.0
-            loss = loss_grade + float(getattr(self, 'lambda_stage_marg', 0.8)) * (loss_stage_marg_ind + float(getattr(self, 'stage_fused_aux_weight', 0.3)) * loss_stage_marg_fused) + float(getattr(self, 'lambda_cond_stage', 0.6)) * (loss_cond_11_12 + loss_cond_21_22) + lambda_soft_joint_eff * loss_soft_joint
+            if is_v2lite:
+                loss_soft_joint = F.nll_loss(torch.log(fused['P_joint6'].clamp_min(1e-8)), targets['joint_id'].long())
+                lambda_soft_joint_eff = float(getattr(self, 'lambda_joint_soft', 0.05) or 0.0)
+                expected_cost = (fused['P_joint6'] * D[targets['joint_id'].long()]).sum(dim=1).mean()
+                loss = loss_grade + float(getattr(self, 'lambda_stage_marg', 1.0)) * loss_stage_marg_ind + float(getattr(self, 'lambda_cond', 0.5)) * (loss_cond_11_12 + loss_cond_21_22) + lambda_soft_joint_eff * loss_soft_joint
+            else:
+                soft_targets = torch.softmax(-D[targets['joint_id'].long()] / max(tau, 1e-6), dim=1)
+                loss_soft_joint = (-(soft_targets * torch.log(fused['P_joint6'].clamp_min(1e-8))).sum(dim=1)).mean()
+                expected_cost = (fused['P_joint6'] * D[targets['joint_id'].long()]).sum(dim=1).mean()
+                lambda_soft_joint_eff = float(getattr(self, 'lambda_soft_joint', 0.15) or 0.0) * self._v2_soft_joint_factor()
+                if getattr(self, 'lpv3_active', False) and self.current_epoch < int(getattr(self, 'lpv3_enable_soft_joint_after_epoch', 10) or 10):
+                    lambda_soft_joint_eff = 0.0
+                loss = loss_grade + float(getattr(self, 'lambda_stage_marg', 0.8)) * (loss_stage_marg_ind + float(getattr(self, 'stage_fused_aux_weight', 0.3)) * loss_stage_marg_fused) + float(getattr(self, 'lambda_cond_stage', 0.6)) * (loss_cond_11_12 + loss_cond_21_22) + lambda_soft_joint_eff * loss_soft_joint
             feature_before = outputs.get('features_before_neck')
             feature_after = outputs.get('shared_features')
             mean_feature_norm_before = float(feature_before.norm(dim=1).mean().detach().cpu()) if isinstance(feature_before, torch.Tensor) else 0.0
@@ -516,11 +549,13 @@ class MultiHeadOrdinalLoss(torch.nn.Module):
                 'loss_cond_11_12': float(loss_cond_11_12.detach().cpu()),
                 'loss_cond_21_22': float(loss_cond_21_22.detach().cpu()),
                 'loss_soft_joint': float(loss_soft_joint.detach().cpu()),
-                'mean_alpha_gate': float(fused['alpha'].mean().detach().cpu()),
+                'mean_alpha_gate': float(fused['alpha'].mean().detach().cpu()) if 'alpha' in fused else 1.0,
                 'mean_q1': float(fused['q1'].mean().detach().cpu()),
                 'mean_q2': float(fused['q2'].mean().detach().cpu()),
                 'mean_expected_joint_graph_cost': float(expected_cost.detach().cpu()),
                 'lambda_soft_joint_eff': float(lambda_soft_joint_eff),
+                'mean_gate_g': float(outputs['gate_g'].mean().detach().cpu()) if 'gate_g' in outputs else 0.0,
+                'mean_gate_s': float(outputs['gate_s'].mean().detach().cpu()) if 'gate_s' in outputs else 0.0,
                 'mean_feature_norm_before_neck': mean_feature_norm_before,
                 'mean_feature_norm_after_neck': mean_feature_norm_after,
                 'mean_neck_norm': mean_feature_norm_after,
@@ -775,6 +810,47 @@ def _collect_outputs_multi(model, data_loader, device, ordinal_mode="default"):
     )
 
 
+def _collect_outputs_multi_v2lite(model, data_loader, device, joint_beta_stage=0.5, joint_gamma_cond=0.5):
+    model.eval()
+    y_grade_all, y_stage_all = [], []
+    p_grade_ge_all, p_stage_ge_all = [], []
+    p_joint6_all, pG_fused_all, pS_fused_all = [], [], []
+    with torch.no_grad():
+        for batch in tqdm(data_loader):
+            if batch is None:
+                continue
+            samples, targets = batch
+            if isinstance(samples, dict):
+                samples = {k: v.float().to(device) if torch.is_tensor(v) else v for k, v in samples.items()}
+            else:
+                samples = samples.float().to(device)
+            out = model(samples)
+            if not (isinstance(out, dict) and all(k in out for k in ["grade_logits", "stage_ind_logits", "q1_logit", "q2_logit"])):
+                raise TypeError("v2lite 验证期期望 dict 输出且包含 grade/stage/q1/q2")
+            p_grade_ge = corn_marginal_ge_probs(torch.sigmoid(out["grade_logits"]))
+            p_stage_ge = corn_marginal_ge_probs(torch.sigmoid(out["stage_ind_logits"]))
+            joint = compose_v2_joint_predictions(
+                p_grade_ge, p_stage_ge, out["q1_logit"], out["q2_logit"],
+                joint_beta_stage=float(joint_beta_stage), joint_gamma_cond=float(joint_gamma_cond), use_entropy_alpha=False,
+            )
+            y_grade_all.append(targets["y_grade"].cpu())
+            y_stage_all.append(targets["y_stage"].cpu())
+            p_grade_ge_all.append(p_grade_ge.cpu())
+            p_stage_ge_all.append(p_stage_ge.cpu())
+            p_joint6_all.append(joint["P_joint6"].cpu())
+            pG_fused_all.append(joint["pG_fused4"].cpu())
+            pS_fused_all.append(joint["pS_fused3"].cpu())
+    return {
+        "y_grade": torch.cat(y_grade_all, dim=0).numpy(),
+        "y_stage": torch.cat(y_stage_all, dim=0).numpy(),
+        "p_grade_ge": torch.cat(p_grade_ge_all, dim=0).numpy(),
+        "p_stage_ge": torch.cat(p_stage_ge_all, dim=0).numpy(),
+        "p_joint6": torch.cat(p_joint6_all, dim=0).numpy(),
+        "pG_fused": torch.cat(pG_fused_all, dim=0).numpy(),
+        "pS_fused": torch.cat(pS_fused_all, dim=0).numpy(),
+    }
+
+
 def _load_ordinal_thresholds(saved_model, args):
     if args.thresholds_json and os.path.exists(args.thresholds_json):
         return load_thresholds_json(args.thresholds_json)
@@ -885,8 +961,11 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
   output_file = os.path.join(output_path, args.exp_name + "_results.txt")
 
   ordinal_datasets = {"advCheX_hyp_multi_level", "advCheX_hyp_multi_stage_v1", "advCheX_hyp_multi_stage_v2"}
-  multihead_datasets = {"advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base"}
+  multihead_datasets = {"advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base", "advCheX_hyp_grade_stage_embtab_v2lite"}
   if args.data_set in ordinal_datasets and (getattr(args, "test_time_adjust", False) or getattr(args, "output_special", False)):
+    if hasattr(dataset_test, "return_path"):
+      dataset_test.return_path = True
+  if args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite" and bool(getattr(args, "return_path", False)):
     if hasattr(dataset_test, "return_path"):
       dataset_test.return_path = True
 
@@ -1010,8 +1089,11 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
         criterion.joint_gamma_cond = float(getattr(args, "joint_gamma_cond", 0.5) or 0.5)
         criterion.v2_soft_joint_start_epoch = int(getattr(args, "v2_soft_joint_start_epoch", 5) or 5)
         criterion.v2_soft_joint_warmup_epochs = int(getattr(args, "v2_soft_joint_warmup_epochs", 5) or 5)
+        criterion.lambda_cond = float(getattr(args, "lambda_cond", 0.5) or 0.0)
+        criterion.lambda_joint_soft = float(getattr(args, "lambda_joint_soft", 0.05) or 0.0)
         criterion.alpha_gate_min = float(getattr(args, "alpha_gate_min", 0.15) or 0.15)
         criterion.alpha_gate_max = float(getattr(args, "alpha_gate_max", 0.65) or 0.65)
+        criterion.data_set = str(getattr(args, "data_set", ""))
         criterion.lpv3_active = _is_lpv3_active(args)
         criterion.lpv3_enable_cond_after_epoch = int(getattr(args, "lpv3_enable_cond_after_epoch", 3) or 3)
         criterion.lpv3_enable_soft_joint_after_epoch = int(getattr(args, "lpv3_enable_soft_joint_after_epoch", 10) or 10)
@@ -1022,6 +1104,9 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
         criterion.joint_graph_w_12_22 = float(getattr(args, "joint_graph_w_12_22", 0.7) or 0.7)
         criterion.joint_graph_w_22_32 = float(getattr(args, "joint_graph_w_22_32", 1.5) or 1.5)
         if args.data_set == "advCheX_hyp_grade_stage_embtab_base":
+          criterion.v1_soft_label_mode = "full"
+          criterion.loss_w_stage_soft = 0.0
+        if args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite":
           criterion.v1_soft_label_mode = "full"
           criterion.loss_w_stage_soft = 0.0
         if getattr(args, "pos_weight_anyhtn", None):
@@ -1217,6 +1302,33 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
               ),
               flush=True,
             )
+          elif args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite":
+            print(
+              "[MultiHead][Loss][v2lite] train: G_main={:.4f} G_soft={:.4f} S_ind={:.4f} "
+              "C_11v12={:.4f} C_21v22={:.4f} J_legal={:.4f} gate_g={:.4f} gate_s={:.4f} total={:.4f} | "
+              "val: G_main={:.4f} G_soft={:.4f} S_ind={:.4f} C_11v12={:.4f} C_21v22={:.4f} J_legal={:.4f} "
+              "gate_g={:.4f} gate_s={:.4f} total={:.4f}".format(
+                train_components.get("loss_grade_main", 0.0),
+                train_components.get("loss_grade_soft", 0.0),
+                train_components.get("loss_stage_marg_ind", 0.0),
+                train_components.get("loss_cond_11_12", 0.0),
+                train_components.get("loss_cond_21_22", 0.0),
+                train_components.get("loss_soft_joint", 0.0),
+                train_components.get("mean_gate_g", 0.0),
+                train_components.get("mean_gate_s", 0.0),
+                train_components.get("loss_total", train_loss),
+                val_components.get("loss_grade_main", 0.0),
+                val_components.get("loss_grade_soft", 0.0),
+                val_components.get("loss_stage_marg_ind", 0.0),
+                val_components.get("loss_cond_11_12", 0.0),
+                val_components.get("loss_cond_21_22", 0.0),
+                val_components.get("loss_soft_joint", 0.0),
+                val_components.get("mean_gate_g", 0.0),
+                val_components.get("mean_gate_s", 0.0),
+                val_components.get("loss_total", val_loss),
+              ),
+              flush=True,
+            )
           elif args.data_set == "advCheX_hyp_multi_grade_stage_sep_v1" and str(getattr(args, "sep_head_mode", "flat")).lower() == "coarse_fine":
             print(
               "[MultiHead][Loss][coarse_fine] train: H_bce={:.4f} H_auc={:.4f} H_total={:.4f} "
@@ -1273,36 +1385,58 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
           else:
             print(f"Epoch {epoch:04d}: val_auc_hypertension=N/A (single class)", flush=True)
         if args.data_set in multihead_datasets:
-          y_grade_val, y_stage_val, p_grade_val, p_stage_val = _collect_outputs_multi(
-            model, data_loader_val, device, ordinal_mode=getattr(args, "ordinal_mode", "default")
-          )
-          prior = build_joint_prior_mimic(
-            np.array([ordinal_targets_to_grade(row) for row in y_grade_val]),
-            np.array([ordinal_targets_to_grade(row) for row in y_stage_val]),
-            eps=getattr(args, "joint_prior_eps", 1e-3),
-          )
-          val_metrics, _, _, _ = evaluate_grade_stage_joint(
-            y_grade_val,
-            y_stage_val,
-            p_grade_val,
-            p_stage_val,
-            prior=prior,
-            prior_alpha=getattr(args, "joint_prior_alpha", 0.2),
-            softacc_gamma_over=getattr(args, "softacc_gamma_over", 0.5),
-            ordinal_mode=getattr(args, "ordinal_mode", "coral").upper(),
-          )
-          val_joint = val_metrics.get("joint_exact_acc_pjoint")
+          if args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite":
+            val_pack = _collect_outputs_multi_v2lite(
+              model, data_loader_val, device,
+              joint_beta_stage=getattr(args, "joint_beta_stage", 0.5),
+              joint_gamma_cond=getattr(args, "joint_gamma_cond", 0.5),
+            )
+            y_grade_val = val_pack["y_grade"]
+            y_stage_val = val_pack["y_stage"]
+            p_grade_val = val_pack["p_grade_ge"]
+            p_stage_val = val_pack["p_stage_ge"]
+            pG_val = val_pack["pG_fused"]
+            pS_val = val_pack["pS_fused"]
+            grade_pred = np.argmax(pG_val, axis=1)
+            stage_pred = np.argmax(pS_val, axis=1)
+            joint_probs = val_pack["p_joint6"]
+            joint_pred = np.argmax(joint_probs, axis=1)
+            joint_true = np.array([
+              JOINT_LABEL_TO_INDEX[(ordinal_targets_to_grade(g), ordinal_targets_to_grade(s))]
+              for g, s in zip(y_grade_val, y_stage_val)
+            ], dtype=np.int64)
+            val_joint = float(np.mean(joint_pred == joint_true)) if joint_true.size > 0 else np.nan
+          else:
+            y_grade_val, y_stage_val, p_grade_val, p_stage_val = _collect_outputs_multi(
+              model, data_loader_val, device, ordinal_mode=getattr(args, "ordinal_mode", "default")
+            )
+            prior = build_joint_prior_mimic(
+              np.array([ordinal_targets_to_grade(row) for row in y_grade_val]),
+              np.array([ordinal_targets_to_grade(row) for row in y_stage_val]),
+              eps=getattr(args, "joint_prior_eps", 1e-3),
+            )
+            val_metrics, _, _, _ = evaluate_grade_stage_joint(
+              y_grade_val,
+              y_stage_val,
+              p_grade_val,
+              p_stage_val,
+              prior=prior,
+              prior_alpha=getattr(args, "joint_prior_alpha", 0.2),
+              softacc_gamma_over=getattr(args, "softacc_gamma_over", 0.5),
+              ordinal_mode=getattr(args, "ordinal_mode", "coral").upper(),
+            )
+            val_joint = val_metrics.get("joint_exact_acc_pjoint")
+            pG_val = ordinal_probs_to_class_probs(p_grade_val)
+            pS_val = ordinal_probs_to_class_probs(p_stage_val)
+            grade_pred = np.argmax(pG_val, axis=1)
+            stage_pred = np.argmax(pS_val, axis=1)
+            joint_probs = compute_joint_distribution(
+              pG_val, pS_val, prior=prior, alpha=getattr(args, "joint_prior_alpha", 0.2)
+            )
+            joint_pred = np.argmax(joint_probs, axis=1)
           if val_joint is not None:
             print(f"Epoch {epoch:04d}: val_joint_exact_acc_pjoint={val_joint:.4f}", flush=True)
           print(f"[MultiHead][Mode] ordinal_mode={getattr(args, 'ordinal_mode', 'default')}", flush=True)
-          pG_val = ordinal_probs_to_class_probs(p_grade_val)
-          pS_val = ordinal_probs_to_class_probs(p_stage_val)
-          grade_pred = np.argmax(pG_val, axis=1)
-          stage_pred = np.argmax(pS_val, axis=1)
-          joint_probs = compute_joint_distribution(
-            pG_val, pS_val, prior=prior, alpha=getattr(args, "joint_prior_alpha", 0.2)
-          )
-          joint_pred = np.argmax(joint_probs, axis=1)
           grade_counts = np.bincount(grade_pred, minlength=4)
           stage_counts = np.bincount(stage_pred, minlength=3)
           joint_counts = np.bincount(joint_pred, minlength=len(JOINT_LABELS))
@@ -1519,6 +1653,7 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
           "advCheX_hyp_multi_grade_stage_v1",
         "advCheX_hyp_multi_grade_stage_sep_v1",
         "advCheX_hyp_grade_stage_embtab_base",
+        "advCheX_hyp_grade_stage_embtab_v2lite",
         }
         if use_cached:
           y_test = read_from_csv(gt_csv)
@@ -1569,8 +1704,12 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
               aux_scores["pG_fused"] = p_test["pG_fused"].cpu().numpy()
               aux_scores["pS_fused"] = p_test["pS_fused"].cpu().numpy()
               aux_scores["alpha_gate"] = p_test["alpha_gate"].cpu().numpy()
+              if "gate_g" in p_test:
+                aux_scores["gate_g"] = p_test["gate_g"].cpu().numpy()
+              if "gate_s" in p_test:
+                aux_scores["gate_s"] = p_test["gate_s"].cpu().numpy()
 
-          if args.data_set in {"advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base"}:
+          if args.data_set in {"advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base", "advCheX_hyp_grade_stage_embtab_v2lite"}:
             output_dir = os.path.dirname(output_file)
             val_y_grade = val_y_stage = val_p_grade = val_p_stage = None
             decoder_mode = str(getattr(args, "decodermode", "non")).lower()
@@ -1605,7 +1744,7 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
                 val_p_stage = p_val_pred["stage"].cpu().numpy()
               else:
                 raise ValueError("Expected multi-head dict outputs on validation decoder pass, but got non-dict outputs.")
-            eval_fn = evaluate_grade_stage_v2 if args.data_set == "advCheX_hyp_grade_stage_v2" else evaluate_grade_stage_sep
+            eval_fn = evaluate_grade_stage_v2 if args.data_set in {"advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_v2lite"} else evaluate_grade_stage_sep
             eval_kwargs = dict(
               output_dir=output_dir, path_list=path_list,
               modethese=getattr(args, "modethese", False),
@@ -1636,7 +1775,7 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
               loss_w_grade_soft=getattr(args, "loss_w_grade_soft", 0.2),
               loss_w_stage_soft=getattr(args, "loss_w_stage_soft", 0.1),
               loss_w_stage_smooth=getattr(args, "loss_w_stage_smooth", 1.0),
-              dataset_tag=("sep_v1" if args.data_set == "advCheX_hyp_multi_grade_stage_sep_v1" else ("v2" if args.data_set == "advCheX_hyp_grade_stage_v2" else ("embtab_base" if args.data_set == "advCheX_hyp_grade_stage_embtab_base" else "v1"))),
+              dataset_tag=("sep_v1" if args.data_set == "advCheX_hyp_multi_grade_stage_sep_v1" else ("v2lite" if args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite" else ("v2" if args.data_set == "advCheX_hyp_grade_stage_v2" else ("embtab_base" if args.data_set == "advCheX_hyp_grade_stage_embtab_base" else "v1")))),
               v1_soft_label_mode=getattr(args, "v1_soft_label_mode", "none"),
               grade_soft_scheme=getattr(args, "grade_soft_scheme", "asym_v1"),
               stage_soft_scheme=getattr(args, "stage_soft_scheme", "asym_v1"),
@@ -1646,11 +1785,13 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
               joint_detach=getattr(args, "joint_detach", "both"),
               incomp_mode=getattr(args, "incomp_mode", "mask_sum"),
             )
-            if args.data_set == "advCheX_hyp_grade_stage_v2":
+            if args.data_set in {"advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_v2lite"}:
               eval_kwargs.update(
                 lambda_stage_marg=getattr(args, "lambda_stage_marg", 0.8),
                 lambda_cond_stage=getattr(args, "lambda_cond_stage", 0.6),
                 lambda_soft_joint=getattr(args, "lambda_soft_joint", 0.15),
+                lambda_cond=getattr(args, "lambda_cond", 0.5),
+                lambda_joint_soft=getattr(args, "lambda_joint_soft", 0.05),
                 stage_fused_aux_weight=getattr(args, "stage_fused_aux_weight", 0.3),
                 cond_pos_weight_g1=getattr(args, "cond_pos_weight_g1", 3.0),
                 cond_pos_weight_g2=getattr(args, "cond_pos_weight_g2", 5.0),
@@ -1669,6 +1810,8 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
                 joint_graph_w_21_22=getattr(args, "joint_graph_w_21_22", 0.8),
                 joint_graph_w_12_22=getattr(args, "joint_graph_w_12_22", 0.7),
                 joint_graph_w_22_32=getattr(args, "joint_graph_w_22_32", 1.5),
+                use_v2lite_fused_eval=getattr(args, "use_v2lite_fused_eval", True),
+                use_legal_joint_composer=getattr(args, "use_legal_joint_composer", True),
               )
             metrics, pred_rows, report_lines = eval_fn(
               y_grade, y_stage, p_grade, p_stage, **eval_kwargs
@@ -1700,6 +1843,22 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
               }
               metrics["embtab_base"] = embtab_summary
               report_lines.extend(["", "[embtab-base summary]"] + [f"{k}={v}" for k, v in embtab_summary.items()])
+            if args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite":
+              v2lite_summary = {
+                "mean_gate_g": float(np.mean(aux_scores["gate_g"])) if "gate_g" in aux_scores else None,
+                "mean_gate_s": float(np.mean(aux_scores["gate_s"])) if "gate_s" in aux_scores else None,
+                "use_stopgrad_grade_for_cond": bool(getattr(args, "use_stopgrad_grade_for_cond", True)),
+                "joint_beta_stage": float(getattr(args, "joint_beta_stage", 0.5)),
+                "joint_gamma_cond": float(getattr(args, "joint_gamma_cond", 0.5)),
+                "cond_pos_weight_g1": float(getattr(args, "cond_pos_weight_g1", 3.0)),
+                "cond_pos_weight_g2": float(getattr(args, "cond_pos_weight_g2", 5.0)),
+                "embtab_v2lite_grade_fusion": "residual_gated",
+                "embtab_v2lite_stage_fusion": "residual_gated",
+                "embtab_v2lite_conditional_stage": True,
+                "embtab_v2lite_stage_soft_label": False,
+              }
+              metrics["embtab_v2lite"] = v2lite_summary
+              report_lines.extend(["", "[embtab-v2lite summary]"] + [f"{k}={v}" for k, v in v2lite_summary.items()])
             with open(os.path.join(output_dir, "metrics.json"), 'w') as fm:
               json.dump(metrics, fm, indent=2, ensure_ascii=False)
             with open(os.path.join(output_dir, "result.txt"), 'w', encoding='utf-8') as fr:
@@ -1909,6 +2068,7 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
         "advCheX_hyp_multi_grade_stage_sep_v1",
         "advCheX_hyp_grade_stage_v2",
         "advCheX_hyp_grade_stage_embtab_base",
+        "advCheX_hyp_grade_stage_embtab_v2lite",
       }:
         return
 

--- a/Finetuning/main_classification.py
+++ b/Finetuning/main_classification.py
@@ -30,7 +30,7 @@ def get_args_parser():
                       default=14, type="int")
     parser.add_option("--num_class_grade", dest="num_class_grade", help="number of grade ordinal logits", default=3, type="int")
     parser.add_option("--num_class_stage", dest="num_class_stage", help="number of stage ordinal logits", default=2, type="int")
-    parser.add_option("--data_set", dest="data_set", help="ChestXray14|CheXpert|Shenzhen|VinDrCXR|RSNAPneumonia|advCheX|advCheX_binary|advCheX_hyp|advCheX_hyp_multi_level|advCheX_hyp_multi_stage_v1|advCheX_hyp_multi_stage_v2|advCheX_hyp_multi_grade_stage_v1|advCheX_hyp_multi_grade_stage_sep_v1|advCheX_hyp_grade_stage_v2|advCheX_hyp_grade_stage_embtab_base", default="ChestXray14", type="string")
+    parser.add_option("--data_set", dest="data_set", help="ChestXray14|CheXpert|Shenzhen|VinDrCXR|RSNAPneumonia|advCheX|advCheX_binary|advCheX_hyp|advCheX_hyp_multi_level|advCheX_hyp_multi_stage_v1|advCheX_hyp_multi_stage_v2|advCheX_hyp_multi_grade_stage_v1|advCheX_hyp_multi_grade_stage_sep_v1|advCheX_hyp_grade_stage_v2|advCheX_hyp_grade_stage_embtab_base|advCheX_hyp_grade_stage_embtab_v2lite", default="ChestXray14", type="string")
     parser.add_option("--normalization", dest="normalization", help="how to normalize data (imagenet|chestx-ray)", default="imagenet",
                       type="string")
     parser.add_option("--img_size", dest="img_size", help="resize image resolution", default=256, type="int")
@@ -126,6 +126,8 @@ def get_args_parser():
     parser.add_option("--print_freq", dest="print_freq", help="print frequency", default=50, type="int")
     parser.add_option("--test_augment", dest="test_augment", help="whether use test time augmentation",
                       default=True, action="callback", callback=vararg_callback_bool)
+    parser.add_option("--return_path", dest="return_path", help="whether return sample paths in test outputs (supported by specific datasets)", default=False,
+                      action="callback", callback=vararg_callback_bool)
     parser.add_option("--anno_percent", dest="anno_percent", help="data percent", default=100, type="int")
     parser.add_option("--device", dest="device", help="cpu|cuda", default="cuda", type="string")
     parser.add_option("--activate", dest="activate", help="Sigmoid", default="Sigmoid", type="string")
@@ -217,16 +219,25 @@ def get_args_parser():
     parser.add_option("--lambda_stage_marg", dest="lambda_stage_marg", default=0.8, type="float")
     parser.add_option("--lambda_cond_stage", dest="lambda_cond_stage", default=0.6, type="float")
     parser.add_option("--lambda_soft_joint", dest="lambda_soft_joint", default=0.15, type="float")
+    parser.add_option("--lambda_cond", dest="lambda_cond", default=0.5, type="float")
+    parser.add_option("--lambda_joint_soft", dest="lambda_joint_soft", default=0.05, type="float")
     parser.add_option("--stage_fused_aux_weight", dest="stage_fused_aux_weight", default=0.3, type="float")
     parser.add_option("--cond_pos_weight_g1", dest="cond_pos_weight_g1", default=3.0, type="float")
     parser.add_option("--cond_pos_weight_g2", dest="cond_pos_weight_g2", default=5.0, type="float")
     parser.add_option("--joint_graph_tau", dest="joint_graph_tau", default=0.7, type="float")
     parser.add_option("--joint_beta_stage", dest="joint_beta_stage", default=0.5, type="float")
     parser.add_option("--joint_gamma_cond", dest="joint_gamma_cond", default=0.5, type="float")
-    parser.add_option("--v2_soft_joint_start_epoch", dest="v2_soft_joint_start_epoch", default=5, type="int")
-    parser.add_option("--v2_soft_joint_warmup_epochs", dest="v2_soft_joint_warmup_epochs", default=5, type="int")
     parser.add_option("--use_stopgrad_grade_for_cond", dest="use_stopgrad_grade_for_cond", default=True,
                       action="callback", callback=vararg_callback_bool)
+    parser.add_option("--use_residual_gated_fusion", dest="use_residual_gated_fusion", default=True,
+                      action="callback", callback=vararg_callback_bool)
+    parser.add_option("--gate_hidden_dim", dest="gate_hidden_dim", default=128, type="int")
+    parser.add_option("--use_v2lite_fused_eval", dest="use_v2lite_fused_eval", default=True,
+                      action="callback", callback=vararg_callback_bool)
+    parser.add_option("--use_legal_joint_composer", dest="use_legal_joint_composer", default=True,
+                      action="callback", callback=vararg_callback_bool)
+    parser.add_option("--v2_soft_joint_start_epoch", dest="v2_soft_joint_start_epoch", default=5, type="int")
+    parser.add_option("--v2_soft_joint_warmup_epochs", dest="v2_soft_joint_warmup_epochs", default=5, type="int")
     parser.add_option("--teacher_force_grade_epochs", dest="teacher_force_grade_epochs", default=0, type="int")
     parser.add_option("--alpha_gate_min", dest="alpha_gate_min", default=0.15, type="float")
     parser.add_option("--alpha_gate_max", dest="alpha_gate_max", default=0.65, type="float")
@@ -788,6 +799,44 @@ def main(args):
             file_path=args.test_list,
             split="test",
             tab_norm_stats=tab_stats_for_test,
+        )
+        classification_engine(args, model_path, output_path, diseases, dataset_train, dataset_val, dataset_test)
+
+    elif args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite":
+        args.num_class_grade = 3
+        args.num_class_stage = 2
+        args.num_class = args.num_class_grade
+        diseases = ["grade", "stage"]
+        val_images_root = args.val_data_dir if getattr(args, "val_data_dir", None) else args.data_dir
+        need_decoder_val = str(getattr(args, "decodermode", "non")).lower() != "non"
+        if args.mode == "train":
+            dataset_train = advCheX_hyp_grade_stage_embtab_v2lite(
+                images_path=args.data_dir, file_path=args.train_list, split="train", tab_norm_stats=None, few_shot=args.few_shot
+            )
+            dataset_val = advCheX_hyp_grade_stage_embtab_v2lite(
+                images_path=val_images_root, file_path=args.val_list, split="valid", tab_norm_stats=dataset_train.tab_norm_stats
+            )
+        else:
+            dataset_train = None
+            if need_decoder_val and args.val_list:
+                dataset_val_train = advCheX_hyp_grade_stage_embtab_v2lite(
+                    images_path=args.data_dir, file_path=args.train_list, split="train", tab_norm_stats=None
+                )
+                dataset_val = advCheX_hyp_grade_stage_embtab_v2lite(
+                    images_path=val_images_root, file_path=args.val_list, split="valid", tab_norm_stats=dataset_val_train.tab_norm_stats
+                )
+            else:
+                dataset_val = None
+        tab_stats_for_test = None
+        if args.mode == "train" and dataset_train is not None:
+            tab_stats_for_test = dataset_train.tab_norm_stats
+        elif args.train_list:
+            dataset_train_for_stats = advCheX_hyp_grade_stage_embtab_v2lite(
+                images_path=args.data_dir, file_path=args.train_list, split="train", tab_norm_stats=None
+            )
+            tab_stats_for_test = dataset_train_for_stats.tab_norm_stats
+        dataset_test = advCheX_hyp_grade_stage_embtab_v2lite(
+            images_path=args.data_dir, file_path=args.test_list, split="test", tab_norm_stats=tab_stats_for_test
         )
         classification_engine(args, model_path, output_path, diseases, dataset_train, dataset_val, dataset_test)
 

--- a/Finetuning/models.py
+++ b/Finetuning/models.py
@@ -39,6 +39,25 @@ if add_safe_globals is not None:
 def build_classification_model(args):
     model = None
     print("Creating model...")
+    if getattr(args, "data_set", "") == "advCheX_hyp_grade_stage_embtab_v2lite":
+        return EmbeddingTabularV2LiteModel(
+            img_emb_dim=getattr(args, "img_emb_dim", 1376),
+            tab_dim=getattr(args, "tab_dim", 5),
+            img_hidden_dim=getattr(args, "img_hidden_dim", 512),
+            img_out_dim=getattr(args, "img_out_dim", 256),
+            tab_hidden_dim=getattr(args, "tab_hidden_dim", 32),
+            tab_out_dim=getattr(args, "tab_out_dim", 64),
+            fusion_hidden_dim=getattr(args, "fusion_hidden_dim", 192),
+            task_hidden_dim=getattr(args, "task_hidden_dim", 128),
+            gate_hidden_dim=getattr(args, "gate_hidden_dim", 128),
+            dropout_img=getattr(args, "dropout_img", 0.2),
+            dropout_tab=getattr(args, "dropout_tab", 0.1),
+            dropout_fusion=getattr(args, "dropout_fusion", 0.2),
+            num_class_grade=getattr(args, "num_class_grade", 3),
+            num_class_stage=getattr(args, "num_class_stage", 2),
+            use_stopgrad_grade_for_cond=getattr(args, "use_stopgrad_grade_for_cond", True),
+            use_residual_gated_fusion=getattr(args, "use_residual_gated_fusion", True),
+        )
     if getattr(args, "data_set", "") == "advCheX_hyp_grade_stage_embtab_base":
         return EmbeddingTabularOrdinalModel(
             img_emb_dim=getattr(args, "img_emb_dim", 1376),
@@ -479,6 +498,128 @@ class EmbeddingTabularOrdinalModel(nn.Module):
         h_g = self.grade_fusion(torch.cat([z_img, self.grade_tab_scale * z_tab], dim=1))
         h_s = self.stage_fusion(torch.cat([z_img, z_tab], dim=1))
         return self.head_grade(h_g), self.head_stage(h_s)
+
+
+class EmbeddingTabularV2LiteModel(nn.Module):
+    def __init__(
+        self,
+        img_emb_dim=1376,
+        tab_dim=5,
+        img_hidden_dim=512,
+        img_out_dim=256,
+        tab_hidden_dim=32,
+        tab_out_dim=64,
+        fusion_hidden_dim=192,
+        task_hidden_dim=128,
+        gate_hidden_dim=128,
+        dropout_img=0.2,
+        dropout_tab=0.1,
+        dropout_fusion=0.2,
+        num_class_grade=3,
+        num_class_stage=2,
+        use_stopgrad_grade_for_cond=True,
+        use_residual_gated_fusion=True,
+    ):
+        super().__init__()
+        self.use_stopgrad_grade_for_cond = bool(use_stopgrad_grade_for_cond)
+        self.use_residual_gated_fusion = bool(use_residual_gated_fusion)
+        self.img_tower = nn.Sequential(
+            nn.LayerNorm(int(img_emb_dim)),
+            nn.Linear(int(img_emb_dim), int(img_hidden_dim)),
+            nn.GELU(),
+            nn.Dropout(float(dropout_img)),
+            nn.Linear(int(img_hidden_dim), int(img_out_dim)),
+            nn.GELU(),
+        )
+        self.tab_tower = nn.Sequential(
+            nn.Linear(int(tab_dim), int(tab_hidden_dim)),
+            nn.ReLU(),
+            nn.Dropout(float(dropout_tab)),
+            nn.Linear(int(tab_hidden_dim), int(tab_out_dim)),
+            nn.ReLU(),
+        )
+        in_dim = int(img_out_dim) + int(tab_out_dim)
+        gate_in_dim = int(task_hidden_dim) + int(tab_out_dim) + 2
+        cond_dim = int(task_hidden_dim) + int(tab_out_dim) + 4
+        self.grade_img_block = nn.Sequential(
+            nn.Linear(int(img_out_dim), int(fusion_hidden_dim)),
+            nn.GELU(),
+            nn.Dropout(float(dropout_fusion)),
+            nn.Linear(int(fusion_hidden_dim), int(task_hidden_dim)),
+            nn.GELU(),
+        )
+        self.grade_corr_block = nn.Sequential(
+            nn.Linear(in_dim, int(task_hidden_dim)),
+            nn.GELU(),
+            nn.Linear(int(task_hidden_dim), int(task_hidden_dim)),
+        )
+        self.grade_gate = nn.Sequential(
+            nn.Linear(gate_in_dim, int(gate_hidden_dim)),
+            nn.ReLU(),
+            nn.Linear(int(gate_hidden_dim), int(task_hidden_dim)),
+            nn.Sigmoid(),
+        )
+        self.stage_img_block = nn.Sequential(
+            nn.Linear(int(img_out_dim), int(fusion_hidden_dim)),
+            nn.GELU(),
+            nn.Dropout(float(dropout_fusion)),
+            nn.Linear(int(fusion_hidden_dim), int(task_hidden_dim)),
+            nn.GELU(),
+        )
+        self.stage_corr_block = nn.Sequential(
+            nn.Linear(in_dim, int(task_hidden_dim)),
+            nn.GELU(),
+            nn.Linear(int(task_hidden_dim), int(task_hidden_dim)),
+        )
+        self.stage_gate = nn.Sequential(
+            nn.Linear(gate_in_dim, int(gate_hidden_dim)),
+            nn.ReLU(),
+            nn.Linear(int(gate_hidden_dim), int(task_hidden_dim)),
+            nn.Sigmoid(),
+        )
+        self.head_grade = nn.Linear(int(task_hidden_dim), int(num_class_grade))
+        self.head_stage = nn.Linear(int(task_hidden_dim), int(num_class_stage))
+        self.head_cond_q1 = nn.Sequential(nn.Linear(cond_dim, 64), nn.ReLU(), nn.Linear(64, 1))
+        self.head_cond_q2 = nn.Sequential(nn.Linear(cond_dim, 64), nn.ReLU(), nn.Linear(64, 1))
+
+    def _grade_probs_from_logits(self, grade_logits):
+        ge = corn_marginal_ge_probs(torch.sigmoid(grade_logits))
+        p = torch.stack([1.0 - ge[:, 0], ge[:, 0] - ge[:, 1], ge[:, 1] - ge[:, 2], ge[:, 2]], dim=1)
+        return p / p.sum(dim=1, keepdim=True).clamp_min(1e-8)
+
+    def forward(self, x):
+        if not isinstance(x, dict):
+            raise ValueError("EmbeddingTabularV2LiteModel 需要 dict 输入: {'img_emb', 'tab'}")
+        z_img = self.img_tower(x["img_emb"])
+        z_tab = self.tab_tower(x["tab"])
+        tab_reliability = x["tab"][:, [1, 4]]
+        fused = torch.cat([z_img, z_tab], dim=1)
+
+        h_g_img = self.grade_img_block(z_img)
+        delta_g = self.grade_corr_block(fused)
+        gate_g = self.grade_gate(torch.cat([h_g_img, z_tab, tab_reliability], dim=1))
+        h_g = h_g_img + gate_g * delta_g if self.use_residual_gated_fusion else h_g_img + delta_g
+        grade_logits = self.head_grade(h_g)
+
+        h_s_img = self.stage_img_block(z_img)
+        delta_s = self.stage_corr_block(fused)
+        gate_s = self.stage_gate(torch.cat([h_s_img, z_tab, tab_reliability], dim=1))
+        h_s = h_s_img + gate_s * delta_s if self.use_residual_gated_fusion else h_s_img + delta_s
+        stage_ind_logits = self.head_stage(h_s)
+
+        pG_ctx = self._grade_probs_from_logits(grade_logits)
+        if self.use_stopgrad_grade_for_cond:
+            pG_ctx = pG_ctx.detach()
+        cond_in = torch.cat([h_s, z_tab, pG_ctx], dim=1)
+        return {
+            "grade_logits": grade_logits,
+            "stage_ind_logits": stage_ind_logits,
+            "q1_logit": self.head_cond_q1(cond_in),
+            "q2_logit": self.head_cond_q2(cond_in),
+            "gate_g": gate_g,
+            "gate_s": gate_s,
+            "pG_ctx": pG_ctx,
+        }
 
 
 

--- a/Finetuning/trainer.py
+++ b/Finetuning/trainer.py
@@ -194,6 +194,8 @@ def test_classification(checkpoint, data_loader_test, device, args):
   pG_fused_test = torch.FloatTensor().cuda()
   pS_fused_test = torch.FloatTensor().cuda()
   alpha_gate_test = torch.FloatTensor().cuda()
+  gate_g_test = torch.FloatTensor().cuda()
+  gate_s_test = torch.FloatTensor().cuda()
   path_list = []
   printed = False
 
@@ -276,6 +278,7 @@ def test_classification(checkpoint, data_loader_test, device, args):
           alpha_gate_max=getattr(args, "alpha_gate_max", 0.65),
           joint_beta_stage=getattr(args, "joint_beta_stage", 0.5),
           joint_gamma_cond=getattr(args, "joint_gamma_cond", 0.5),
+          use_entropy_alpha=(getattr(args, "data_set", "") != "advCheX_hyp_grade_stage_embtab_v2lite"),
         )
         out_grade_mean = raw_grade_ge.view(bs, n_crops, -1).mean(1)
         out_stage_mean = raw_stage_ge.view(bs, n_crops, -1).mean(1)
@@ -287,6 +290,10 @@ def test_classification(checkpoint, data_loader_test, device, args):
         pG_fused_test = torch.cat((pG_fused_test, joint["pG_fused4"].view(bs, n_crops, -1).mean(1).data), 0)
         pS_fused_test = torch.cat((pS_fused_test, joint["pS_fused3"].view(bs, n_crops, -1).mean(1).data), 0)
         alpha_gate_test = torch.cat((alpha_gate_test, joint["alpha"].view(bs, n_crops, -1).mean(1).data), 0)
+        if "gate_g" in out:
+          gate_g_test = torch.cat((gate_g_test, out["gate_g"].view(bs, n_crops, -1).mean(1).data), 0)
+        if "gate_s" in out:
+          gate_s_test = torch.cat((gate_s_test, out["gate_s"].view(bs, n_crops, -1).mean(1).data), 0)
       elif isinstance(out, tuple):
         out_grade, out_stage = out
         if str(getattr(args, "ordinal_mode", "coral")).lower() == "corn":
@@ -325,6 +332,10 @@ def test_classification(checkpoint, data_loader_test, device, args):
         "pS_fused": pS_fused_test,
         "alpha_gate": alpha_gate_test,
       })
+      if gate_g_test.numel() > 0:
+        p_dict["gate_g"] = gate_g_test
+      if gate_s_test.numel() > 0:
+        p_dict["gate_s"] = gate_s_test
     if path_list:
       return y_dict, p_dict, path_list
     return y_dict, p_dict

--- a/Finetuning/utils.py
+++ b/Finetuning/utils.py
@@ -1,4 +1,4 @@
-from sklearn.metrics import roc_curve, roc_auc_score, accuracy_score, average_precision_score, f1_score, matthews_corrcoef, recall_score, confusion_matrix, brier_score_loss
+from sklearn.metrics import roc_curve, roc_auc_score, accuracy_score, average_precision_score, f1_score, matthews_corrcoef, recall_score, confusion_matrix, brier_score_loss, precision_score
 import torch
 import numpy as np
 import json
@@ -1759,12 +1759,15 @@ def build_v2_joint_graph_distance_matrix_numpy(joint_graph_w_00_11=1.0, joint_gr
 
 
 def compose_v2_joint_predictions(p_ge_grade, p_ge_stage, q1_logit, q2_logit, alpha_gate_min=0.15, alpha_gate_max=0.65,
-                                 joint_beta_stage=0.5, joint_gamma_cond=0.5, eps=1e-8):
+                                 joint_beta_stage=0.5, joint_gamma_cond=0.5, eps=1e-8, use_entropy_alpha=True):
     pG = corn_probs_to_class_probs_torch(p_ge_grade)
     pS = corn_probs_to_class_probs_torch(p_ge_stage)
     if isinstance(pG, torch.Tensor):
-        H = -(pG.clamp_min(eps) * torch.log(pG.clamp_min(eps))).sum(dim=1) / np.log(4.0)
-        alpha = alpha_gate_min + (alpha_gate_max - alpha_gate_min) * H
+        if use_entropy_alpha:
+            H = -(pG.clamp_min(eps) * torch.log(pG.clamp_min(eps))).sum(dim=1) / np.log(4.0)
+            alpha = alpha_gate_min + (alpha_gate_max - alpha_gate_min) * H
+        else:
+            alpha = torch.ones((pG.shape[0],), dtype=pG.dtype, device=pG.device)
         q1 = torch.sigmoid(q1_logit.view(-1))
         q2 = torch.sigmoid(q2_logit.view(-1))
         pg = pG.clamp(eps, 1.0); ps = pS.clamp(eps, 1.0); q1c = q1.clamp(eps, 1.0 - eps); q2c = q2.clamp(eps, 1.0 - eps)
@@ -1898,6 +1901,83 @@ def evaluate_grade_stage_v2(y_grade, y_stage, p_ge_grade, p_ge_stage, output_dir
         },
         'joint_graph_distance_matrix': D.tolist(),
     })
+    is_v2lite_tag = str(dataset_tag).lower() == "v2lite"
+    if is_v2lite_tag:
+        prob_grade_any_fused = 1.0 - pG_fused[:, 0]
+        prob_stage_any_fused = 1.0 - pS_fused[:, 0]
+        metrics.update({
+            'MAE_grade_fused': float(np.mean(np.abs(grade_pred_fused - grades_true))),
+            'MAE_stage_fused': float(np.mean(np.abs(stage_pred_fused - stages_true))),
+            'QWK_grade_fused': _safe_kappa(grades_true, grade_pred_fused),
+            'QWK_stage_fused': _safe_kappa(stages_true, stage_pred_fused),
+            'ACC_grade_fused': float(np.mean(grade_pred_fused == grades_true)),
+            'ACC_stage_fused': float(np.mean(stage_pred_fused == stages_true)),
+            'ACC_joint6_fused': float(np.mean(joint_pred_fused == joint_gt)),
+            'AUROC_grade_any_htn_fused': safe_roc_auc((grades_true > 0).astype(int), prob_grade_any_fused),
+            'AUROC_grade_ge2_fused': safe_roc_auc((grades_true >= 2).astype(int), pG_fused[:, 2] + pG_fused[:, 3]),
+            'AUROC_grade_ge3_fused': safe_roc_auc((grades_true >= 3).astype(int), pG_fused[:, 3]),
+            'AUROC_stage_any_htn_fused': safe_roc_auc((stages_true > 0).astype(int), prob_stage_any_fused),
+            'AUROC_stage_ge2_fused': safe_roc_auc((stages_true >= 2).astype(int), pS_fused[:, 2]),
+        })
+        _plot_roc_curve((grades_true > 0).astype(int), prob_grade_any_fused, "ROC grade any HTN (fused)", os.path.join(output_dir, "roc_grade_any_htn_fused.png"))
+        _plot_roc_comparison(
+            [("grade>=1(any_htn)", (grades_true > 0).astype(int), prob_grade_any_fused),
+             ("grade>=2", (grades_true >= 2).astype(int), pG_fused[:, 2] + pG_fused[:, 3]),
+             ("grade>=3", (grades_true >= 3).astype(int), pG_fused[:, 3])],
+            "ROC Grade Comparison (fused)",
+            os.path.join(output_dir, "roc_grade_comparison_fused.png"),
+        )
+        _plot_roc_curve((stages_true > 0).astype(int), prob_stage_any_fused, "ROC stage any HTN (fused)", os.path.join(output_dir, "roc_stage_any_htn_fused.png"))
+        _plot_roc_comparison(
+            [("stage>=1(any_htn)", (stages_true > 0).astype(int), prob_stage_any_fused),
+             ("stage>=2", (stages_true >= 2).astype(int), pS_fused[:, 2])],
+            "ROC Stage Comparison (fused)",
+            os.path.join(output_dir, "roc_stage_comparison_fused.png"),
+        )
+
+        def _ovr_pack(y_true, y_pred, labels, prefix):
+            y_true = np.asarray(y_true).astype(int)
+            y_pred = np.asarray(y_pred).astype(int)
+            out = {}
+            support = np.array([(y_true == c).sum() for c in labels], dtype=np.float64)
+            w = support / max(support.sum(), 1.0)
+            p_list, r_list, s_list, a_list = [], [], [], []
+            for idx, c in enumerate(labels):
+                yt = (y_true == c).astype(np.int32)
+                yp = (y_pred == c).astype(np.int32)
+                tp = float(np.sum((yt == 1) & (yp == 1)))
+                tn = float(np.sum((yt == 0) & (yp == 0)))
+                fp = float(np.sum((yt == 0) & (yp == 1)))
+                fn = float(np.sum((yt == 1) & (yp == 0)))
+                precision = tp / max(tp + fp, 1.0)
+                recall = tp / max(tp + fn, 1.0)  # sensitivity
+                specificity = tn / max(tn + fp, 1.0)
+                accuracy = (tp + tn) / max(tp + tn + fp + fn, 1.0)
+                p_list.append(precision); r_list.append(recall); s_list.append(specificity); a_list.append(accuracy)
+                out[f"{prefix}_class_{c}"] = {
+                    "precision": float(precision),
+                    "sensitivity": float(recall),
+                    "specificity": float(specificity),
+                    "accuracy": float(accuracy),
+                    "support": int(support[idx]),
+                }
+            out[f"{prefix}_macro_avg"] = {
+                "precision": float(np.mean(p_list)),
+                "sensitivity": float(np.mean(r_list)),
+                "specificity": float(np.mean(s_list)),
+                "accuracy": float(np.mean(a_list)),
+            }
+            out[f"{prefix}_weighted_avg"] = {
+                "precision": float(np.sum(np.array(p_list) * w)),
+                "sensitivity": float(np.sum(np.array(r_list) * w)),
+                "specificity": float(np.sum(np.array(s_list) * w)),
+                "accuracy": float(np.sum(np.array(a_list) * w)),
+            }
+            return out
+
+        metrics["ovr_joint6_fused"] = _ovr_pack(joint_gt, joint_pred_fused, labels=[0,1,2,3,4,5], prefix="joint6_fused")
+        metrics["ovr_grade_fused"] = _ovr_pack(grades_true, grade_pred_fused, labels=[0,1,2,3], prefix="grade_fused")
+        metrics["ovr_stage_fused"] = _ovr_pack(stages_true, stage_pred_fused, labels=[0,1,2], prefix="stage_fused")
     mask_g1 = grades_true == 1
     mask_g2 = grades_true == 2
     metrics['AUC_cond_11_vs12'] = safe_roc_auc((stages_true[mask_g1] == 1).astype(int), q1[mask_g1]) if mask_g1.sum() > 1 else np.nan
@@ -1920,4 +2000,36 @@ def evaluate_grade_stage_v2(y_grade, y_stage, p_ge_grade, p_ge_stage, output_dir
         'teacher_force_grade_epochs': metrics['teacher_force_grade_epochs'],
         'graph_edge_weights_summary': metrics['graph_edge_weights_summary'],
     }, ensure_ascii=False)])
+    if is_v2lite_tag:
+        report_lines.extend([
+            "",
+            "[v2lite fused scalar metrics]",
+            f"MAE_grade_fused={metrics['MAE_grade_fused']}",
+            f"QWK_grade_fused={metrics['QWK_grade_fused']}",
+            f"MAE_stage_fused={metrics['MAE_stage_fused']}",
+            f"QWK_stage_fused={metrics['QWK_stage_fused']}",
+            f"ACC_grade_fused={metrics['ACC_grade_fused']}",
+            f"ACC_stage_fused={metrics['ACC_stage_fused']}",
+            f"ACC_joint6_fused={metrics['ACC_joint6_fused']}",
+            f"AUROC_grade_any_htn_fused={metrics['AUROC_grade_any_htn_fused']}",
+            f"AUROC_grade_ge2_fused={metrics['AUROC_grade_ge2_fused']}",
+            f"AUROC_grade_ge3_fused={metrics['AUROC_grade_ge3_fused']}",
+            f"AUROC_stage_any_htn_fused={metrics['AUROC_stage_any_htn_fused']}",
+            f"AUROC_stage_ge2_fused={metrics['AUROC_stage_ge2_fused']}",
+            "",
+            "[v2lite fused ovr metrics - joint6]",
+            json.dumps(metrics["ovr_joint6_fused"], ensure_ascii=False),
+            "",
+            "[v2lite fused ovr metrics - grade]",
+            json.dumps(metrics["ovr_grade_fused"], ensure_ascii=False),
+            "",
+            "[v2lite fused ovr metrics - stage]",
+            json.dumps(metrics["ovr_stage_fused"], ensure_ascii=False),
+            "",
+            "[v2lite fused ROC]",
+            "roc_grade_any_htn_fused.png",
+            "roc_grade_comparison_fused.png",
+            "roc_stage_any_htn_fused.png",
+            "roc_stage_comparison_fused.png",
+        ])
     return metrics, rows, report_lines


### PR DESCRIPTION
### Motivation

- Introduce a lightweight embedding+tabular v2-lite pipeline to reuse embtab-base data loading and provide a specialized fused model and evaluation suited for v2-lite experiments.
- Add loss/evaluation handling and CLI flags to operate v2-lite as a first-class dataset within the multi-head grade/stage training and testing flow.

### Description

- Added dataset subclass `advCheX_hyp_grade_stage_embtab_v2lite` that reuses `advCheX_hyp_grade_stage_embtab_base` loading behavior in `Finetuning/dataloader.py`.
- Implemented `EmbeddingTabularV2LiteModel` in `Finetuning/models.py` and hooked it into `build_classification_model` to return the v2-lite model when `args.data_set` is set accordingly; the model returns `grade_logits`, `stage_ind_logits`, `q1_logit`, `q2_logit`, gate outputs and a detached grade context `pG_ctx` for conditional heads.
- Extended `MultiHeadOrdinalLoss` in `Finetuning/engine.py` with `_v2lite_joint_from_outputs` and a conditional branch that composes a simpler v2-lite loss (legal joint NLL + adjusted weights) when `data_set` equals the v2-lite tag; added `lambda_cond` and `lambda_joint_soft` criterion attributes and stored `data_set` on `criterion`.
- Added `_collect_outputs_multi_v2lite` helper and integrated a v2-lite-specific evaluation path in `classification_engine`, including fused output handling and v2-lite-specific reporting and summary fields.
- Updated `Finetuning/main_classification.py` to expose new CLI flags (e.g., `--return_path`, `--lambda_cond`, `--lambda_joint_soft`, `--use_residual_gated_fusion`, `--gate_hidden_dim`, `--use_v2lite_fused_eval`, `--use_legal_joint_composer`) and to create train/val/test datasets for `advCheX_hyp_grade_stage_embtab_v2lite` in the main dispatch.
- Collected gate outputs in `Finetuning/trainer.py` test path and include them in returned prediction dicts; small utils change `compose_v2_joint_predictions` adds `use_entropy_alpha` to optionally disable entropy-based alpha for v2-lite; `evaluate_grade_stage_v2` extended with v2-lite fused metrics, ROC plots and OVR packing and reporting.
- Minor imports and metric additions in `Finetuning/utils.py`.

### Testing

- Ran a basic smoke forward pass by building the v2-lite model via `build_classification_model` and executing a single forward with dummy `img_emb`/`tab` tensors, which completed successfully.
- Performed a minimal end-to-end smoke test of `test_classification` with a small synthetic DataLoader to verify outputs include fused probabilities and gate values, and the classification engine path for the v2-lite dataset runs to completion. All smoke tests passed.
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ff3ca048833192410e8447758ec3)