### PR TITLE
Add clinical-ML baseline, simple tabular/image/concat models, dataset flag and baseline test scripts

### DIFF
--- a/Finetuning/baselines/train_clinical_only_ml.py
+++ b/Finetuning/baselines/train_clinical_only_ml.py
@@ -1,0 +1,171 @@
+import argparse, os, json
+import numpy as np, pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier, HistGradientBoostingClassifier
+from sklearn.metrics import confusion_matrix, cohen_kappa_score, roc_auc_score
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+TAB_COLS=["age_abs","age_topcoded","sex_bin","bmi_stat","bmi_missing"]
+LEGAL={(0,0),(1,1),(1,2),(2,1),(2,2),(3,2)}
+
+
+def safe_auc(y, s):
+    y=np.asarray(y)
+    if len(np.unique(y)) < 2:
+        return np.nan
+    return float(roc_auc_score(y, s))
+
+
+def load_df(p):
+    return pd.read_csv(p)
+
+
+def fit_norm(df):
+    return {
+        "age_mean": float(df["age_abs"].mean()),
+        "age_std": float(df["age_abs"].std() + 1e-8),
+        "bmi_mean": float(df["bmi_stat"].mean()),
+        "bmi_std": float(df["bmi_stat"].std() + 1e-8),
+    }
+
+
+def xform(df, s):
+    x = df[TAB_COLS].copy()
+    x["age_abs"] = (x["age_abs"] - s["age_mean"]) / s["age_std"]
+    x["bmi_stat"] = (x["bmi_stat"] - s["bmi_mean"]) / s["bmi_std"]
+    return x.values.astype(np.float32)
+
+
+def make_model(kind):
+    if kind == "lr":
+        return LogisticRegression(max_iter=3000, multi_class="multinomial")
+    if kind == "rf":
+        return RandomForestClassifier(n_estimators=500, random_state=42)
+    if kind == "lightgbm":
+        try:
+            from lightgbm import LGBMClassifier
+            return LGBMClassifier(n_estimators=500, random_state=42)
+        except Exception:
+            return HistGradientBoostingClassifier(random_state=42)
+    if kind == "hgb":
+        return HistGradientBoostingClassifier(random_state=42)
+    raise ValueError(kind)
+
+
+def plot_confmat(cm, labels, title, savep):
+    fig, ax = plt.subplots(figsize=(5, 4))
+    im = ax.imshow(cm, cmap='Blues')
+    ax.set_xticks(range(len(labels))); ax.set_yticks(range(len(labels)))
+    ax.set_xticklabels(labels); ax.set_yticklabels(labels)
+    ax.set_title(title)
+    for i in range(cm.shape[0]):
+        for j in range(cm.shape[1]):
+            ax.text(j, i, str(cm[i, j]), ha='center', va='center')
+    fig.colorbar(im, ax=ax)
+    fig.tight_layout(); fig.savefig(savep, dpi=200); plt.close(fig)
+
+
+def eval_one(df, pg, ps, outdir):
+    os.makedirs(outdir, exist_ok=True)
+    y_g = df['grade'].astype(int).values
+    y_s = df['stage'].astype(int).values
+    pred_g = pg.argmax(1)
+    pred_s = ps.argmax(1)
+
+    p_any_g = 1.0 - pg[:, 0]
+    p_ge2 = pg[:, 2] + pg[:, 3]
+    p_ge3 = pg[:, 3]
+    p_any_s = 1.0 - ps[:, 0]
+    p_sge2 = ps[:, 2]
+
+    invalid = np.array([(int(g), int(s)) not in LEGAL for g, s in zip(pred_g, pred_s)], dtype=int)
+    invalid_type = [f"g{int(g)}_s{int(s)}" if iv else "" for g, s, iv in zip(pred_g, pred_s, invalid)]
+
+    cm_g = confusion_matrix(y_g, pred_g, labels=[0, 1, 2, 3])
+    cm_s = confusion_matrix(y_s, pred_s, labels=[0, 1, 2])
+    plot_confmat(cm_g, ['0','1','2','3'], 'Grade Confmat', os.path.join(outdir, 'Confmat_grade.png'))
+    plot_confmat(cm_s, ['0','1','2'], 'Stage Confmat', os.path.join(outdir, 'Confmat_stage.png'))
+
+    cnt = {}
+    for t in invalid_type:
+        if t:
+            cnt[t] = cnt.get(t, 0) + 1
+    fig, ax = plt.subplots(figsize=(6, 4))
+    if cnt:
+        ax.bar(list(cnt.keys()), list(cnt.values())); ax.tick_params(axis='x', rotation=45)
+    ax.set_title('Invalid type histogram'); fig.tight_layout(); fig.savefig(os.path.join(outdir, 'invalid_type_hist.png'), dpi=200); plt.close(fig)
+
+    metrics = {
+        'QWK_grade': float(cohen_kappa_score(y_g, pred_g, weights='quadratic')),
+        'QWK_stage': float(cohen_kappa_score(y_s, pred_s, weights='quadratic')),
+        'AUROC_grade_any_htn': safe_auc((y_g > 0).astype(int), p_any_g),
+        'AUROC_grade_ge2': safe_auc((y_g >= 2).astype(int), p_ge2),
+        'AUROC_grade_ge3': safe_auc((y_g >= 3).astype(int), p_ge3),
+        'AUROC_stage_any_htn': safe_auc((y_s > 0).astype(int), p_any_s),
+        'AUROC_stage_ge2': safe_auc((y_s >= 2).astype(int), p_sge2),
+        'invalid_rate': float(invalid.mean()),
+    }
+
+    pd.DataFrame({
+        'Path': df.get('Path', pd.Series([''] * len(df))),
+        'grade_gt': y_g, 'stage_gt': y_s,
+        'grade_pred': pred_g, 'stage_pred': pred_s,
+        'prob_grade_any_htn': p_any_g, 'prob_stage_any_htn': p_any_s,
+        'invalid_flag': invalid, 'invalid_type': invalid_type,
+    }).to_csv(os.path.join(outdir, 'predictions.csv'), index=False)
+
+    with open(os.path.join(outdir, 'metrics.json'), 'w', encoding='utf-8') as f:
+        json.dump(metrics, f, indent=2, ensure_ascii=False)
+
+    with open(os.path.join(outdir, 'result.txt'), 'w', encoding='utf-8') as f:
+        f.write('[scalar metrics]\n')
+        for k, v in metrics.items():
+            f.write(f'{k}={v}\n')
+        f.write('\n[Confmat_grade labels=0,1,2,3]\n')
+        f.write(np.array2string(cm_g, separator=', ') + '\n\n')
+        f.write('[Confmat_stage labels=0,1,2]\n')
+        f.write(np.array2string(cm_s, separator=', ') + '\n\n')
+        f.write('[invalid_type_count]\n')
+        f.write(json.dumps(cnt, ensure_ascii=False, sort_keys=True) + '\n\n')
+        f.write('[generated_figures]\nConfmat_grade.png\nConfmat_stage.png\ninvalid_type_hist.png\n')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--train_csv', required=True)
+    ap.add_argument('--valid_csv', required=True)
+    ap.add_argument('--test_csv', required=True)
+    ap.add_argument('--external_csvs', nargs='*', default=[])
+    ap.add_argument('--external_names', nargs='*', default=[])
+    ap.add_argument('--model_type', choices=['lr', 'rf', 'lightgbm', 'hgb'], default='lr')
+    ap.add_argument('--out_root', required=True)
+    args = ap.parse_args()
+
+    tr = load_df(args.train_csv)
+    te = load_df(args.test_csv)
+    stats = fit_norm(tr)
+    Xtr = xform(tr, stats)
+    Xte = xform(te, stats)
+
+    yg = tr['grade'].astype(int).values
+    ys = tr['stage'].astype(int).values
+    mg, ms = make_model(args.model_type), make_model(args.model_type)
+    mg.fit(Xtr, yg)
+    ms.fit(Xtr, ys)
+
+    os.makedirs(args.out_root, exist_ok=True)
+    with open(os.path.join(args.out_root, 'norm_stats.json'), 'w', encoding='utf-8') as f:
+        json.dump(stats, f, indent=2, ensure_ascii=False)
+
+    eval_one(te, mg.predict_proba(Xte), ms.predict_proba(Xte), os.path.join(args.out_root, 'internal'))
+    for i, csvp in enumerate(args.external_csvs):
+        name = args.external_names[i] if i < len(args.external_names) else f'external_{i}'
+        d = load_df(csvp)
+        X = xform(d, stats)
+        eval_one(d, mg.predict_proba(X), ms.predict_proba(X), os.path.join(args.out_root, name))
+
+
+if __name__ == '__main__':
+    main()

--- a/Finetuning/change_log.md
+++ b/Finetuning/change_log.md
@@ -1,0 +1,42 @@
+# Change Log
+
+## 2026-05-06 baseline comparison extension
+
+- Added three new PyTorch baseline dataset/model routes:
+  - `advCheX_hyp_grade_stage_tab_only`
+  - `advCheX_hyp_grade_stage_imgemb_only`
+  - `advCheX_hyp_grade_stage_simple_concat_fusion`
+- Added model classes:
+  - `TabularOnlyOrdinalModel`
+  - `EmbeddingOnlyOrdinalModel`
+  - `SimpleConcatFusionOrdinalModel`
+- Extended embtab dataset to support `load_img_emb=False` for tabular-only speed-up.
+- Extended engine multi-head evaluation whitelist to include the new baselines so existing decoder/result pipeline remains reusable.
+- Added clinical traditional ML baseline script:
+  - `Finetuning/baselines/train_clinical_only_ml.py`
+- Added baseline scripts:
+  - `Finetuning/scripts/baseline_comparison/train_tabular_only_mlp.sh`
+  - `Finetuning/scripts/baseline_comparison/test_baseline_multi_cohort.sh`
+  - `Finetuning/scripts/baseline_comparison/run_clinical_ml.sh`
+
+Compatibility note:
+- Existing modes (`embtab-base`, `embtab-v2lite`, `v1`, `sep_v1`) are untouched in their original dataset names, model classes, and script interface.
+
+## 2026-05-07 baseline output completeness update
+
+- Added dedicated training scripts for all new neural baselines:
+  - `train_tabular_only_mlp.sh`
+  - `train_image_only_mlp.sh`
+  - `train_simple_concat_fusion_mlp.sh`
+- Added dedicated auto-test scripts for each new mode:
+  - `test_tabular_only_mlp_auto.sh`
+  - `test_image_only_mlp_auto.sh`
+  - `test_simple_concat_fusion_mlp_auto.sh`
+  - `test_clinical_ml_auto.sh`
+- Upgraded `test_baseline_multi_cohort.sh` to copy full artifacts (`png/json/csv/txt`) and generate `run_info.txt` per cohort/decoder.
+- Enhanced clinical ML baseline outputs to include:
+  - AUROC/QWK metrics in `metrics.json` and `result.txt`
+  - `Confmat_grade.png`, `Confmat_stage.png`, `invalid_type_hist.png`
+  - `predictions.csv`
+  - structured invalid-type count section in `result.txt`
+- Added LightGBM option with automatic fallback to HGB if LightGBM is unavailable.

--- a/Finetuning/dataloader.py
+++ b/Finetuning/dataloader.py
@@ -1141,7 +1141,7 @@ class advCheX_hyp_grade_stage_embtab_base(Dataset):
 
     TAB_COLS = ["age_abs", "age_topcoded", "sex_bin", "bmi_stat", "bmi_missing"]
 
-    def __init__(self, images_path, file_path, split="train", tab_norm_stats=None, few_shot=-1):
+    def __init__(self, images_path, file_path, split="train", tab_norm_stats=None, few_shot=-1, load_img_emb=True):
         self.images_path = images_path
         self.file_path = file_path
         self.split = str(split).lower()
@@ -1153,6 +1153,7 @@ class advCheX_hyp_grade_stage_embtab_base(Dataset):
         self.tab_list = []
         self.joint_ids = []
         self.tab_norm_stats = dict(tab_norm_stats) if tab_norm_stats is not None else None
+        self.load_img_emb = bool(load_img_emb)
 
         with open(file_path, "r") as f:
             csv_reader = csv.DictReader(f)
@@ -1252,8 +1253,11 @@ class advCheX_hyp_grade_stage_embtab_base(Dataset):
 
     def __getitem__(self, index):
         emb_path = self.img_list[index]
-        img_emb = np.load(emb_path)
-        img_emb = np.asarray(img_emb, dtype=np.float32).reshape(-1)
+        if self.load_img_emb:
+            img_emb = np.load(emb_path)
+            img_emb = np.asarray(img_emb, dtype=np.float32).reshape(-1)
+        else:
+            img_emb = np.zeros((1376,), dtype=np.float32)
         tab = np.asarray(self.tab_list[index], dtype=np.float32)
         grade = int(self.grade_list[index])
         stage = int(self.stage_list[index])

--- a/Finetuning/engine.py
+++ b/Finetuning/engine.py
@@ -568,6 +568,52 @@ class MultiHeadOrdinalLoss(torch.nn.Module):
             }
             return loss
 
+        if isinstance(outputs, dict) and all(k in outputs for k in ["grade_logits", "stage_ind_logits"]):
+            logits_grade = outputs["grade_logits"]
+            logits_stage = outputs["stage_ind_logits"]
+            y_grade = targets["y_grade"]
+            y_stage = targets["y_stage"]
+            if str(self.ordinal_mode).lower() == "corn":
+                loss_grade_base = self._corn_task_loss(logits_grade, y_grade, pos_weight=self.loss_grade.pos_weight)
+                loss_stage_base = self._corn_task_loss(logits_stage, y_stage, pos_weight=self.loss_stage.pos_weight)
+                ge_g = corn_marginal_ge_probs(torch.sigmoid(logits_grade))
+                ge_s = corn_marginal_ge_probs(torch.sigmoid(logits_stage))
+            else:
+                loss_grade_base = self.loss_grade(logits_grade, y_grade)
+                loss_stage_base = self.loss_stage(logits_stage, y_stage)
+                ge_g = torch.sigmoid(logits_grade)
+                ge_s = torch.sigmoid(logits_stage)
+
+            loss_grade_soft = loss_grade_base.new_tensor(0.0)
+            loss_stage_soft = loss_stage_base.new_tensor(0.0)
+            if str(getattr(self, "v1_soft_label_mode", "none") or "none").lower() == "full":
+                raw_grade = targets.get("raw_grade")
+                raw_stage = targets.get("raw_stage")
+                if raw_grade is None:
+                    raw_grade = torch.sum(y_grade > 0.5, dim=1).long()
+                if raw_stage is None:
+                    raw_stage = torch.sum(y_stage > 0.5, dim=1).long()
+                pG_full = self._build_full_grade_probs_from_ge(ge_g)
+                pS_full = self._build_full_stage_probs_from_ge(ge_s)
+                y_grade_soft = self._build_v1_grade_soft_targets(raw_grade, getattr(self, "grade_soft_scheme", "asym_v1"))
+                y_stage_soft = self._build_v1_stage_soft_targets(raw_stage, getattr(self, "stage_soft_scheme", "asym_v1"))
+                loss_grade_soft = self._compute_soft_ce(pG_full, y_grade_soft)
+                loss_stage_soft = self._compute_soft_ce(pS_full, y_stage_soft)
+
+            loss_grade = loss_grade_base + float(getattr(self, "loss_w_grade_soft", 0.2) or 0.0) * loss_grade_soft
+            loss_stage = loss_stage_base + float(getattr(self, "loss_w_stage_soft", 0.1) or 0.0) * loss_stage_soft
+            loss = self.w_grade * loss_grade + self.w_stage * loss_stage
+            self.last_components = {
+                "loss_grade": float(loss_grade.detach().cpu().item()),
+                "loss_stage": float(loss_stage.detach().cpu().item()),
+                "loss_grade_base": float(loss_grade_base.detach().cpu().item()),
+                "loss_stage_base": float(loss_stage_base.detach().cpu().item()),
+                "loss_grade_soft": float(loss_grade_soft.detach().cpu().item()),
+                "loss_stage_soft": float(loss_stage_soft.detach().cpu().item()),
+                "loss_total": float(loss.detach().cpu().item()),
+            }
+            return loss
+
         logits_grade, logits_stage = outputs
         y_grade = targets["y_grade"]
         y_stage = targets["y_stage"]
@@ -788,6 +834,15 @@ def _collect_outputs_multi(model, data_loader, device, ordinal_mode="default"):
                 else:
                     p_grade = torch.sigmoid(logits_grade)
                     p_stage = torch.sigmoid(logits_stage)
+            elif isinstance(out, dict) and all(k in out for k in ["grade_logits", "stage_ind_logits"]):
+                logits_grade = out["grade_logits"]
+                logits_stage = out["stage_ind_logits"]
+                if str(ordinal_mode).lower() == "corn":
+                    p_grade = corn_marginal_ge_probs(torch.sigmoid(logits_grade))
+                    p_stage = corn_marginal_ge_probs(torch.sigmoid(logits_stage))
+                else:
+                    p_grade = torch.sigmoid(logits_grade)
+                    p_stage = torch.sigmoid(logits_stage)
             elif isinstance(out, tuple) and len(out) == 2:
                 logits_grade, logits_stage = out
                 if str(ordinal_mode).lower() == "corn":
@@ -961,7 +1016,7 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
   output_file = os.path.join(output_path, args.exp_name + "_results.txt")
 
   ordinal_datasets = {"advCheX_hyp_multi_level", "advCheX_hyp_multi_stage_v1", "advCheX_hyp_multi_stage_v2"}
-  multihead_datasets = {"advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base", "advCheX_hyp_grade_stage_embtab_v2lite"}
+  multihead_datasets = {"advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base", "advCheX_hyp_grade_stage_embtab_v2lite", "advCheX_hyp_grade_stage_tab_only", "advCheX_hyp_grade_stage_imgemb_only", "advCheX_hyp_grade_stage_simple_concat_fusion"}
   if args.data_set in ordinal_datasets and (getattr(args, "test_time_adjust", False) or getattr(args, "output_special", False)):
     if hasattr(dataset_test, "return_path"):
       dataset_test.return_path = True
@@ -1654,6 +1709,9 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
         "advCheX_hyp_multi_grade_stage_sep_v1",
         "advCheX_hyp_grade_stage_embtab_base",
         "advCheX_hyp_grade_stage_embtab_v2lite",
+        "advCheX_hyp_grade_stage_tab_only",
+        "advCheX_hyp_grade_stage_imgemb_only",
+        "advCheX_hyp_grade_stage_simple_concat_fusion",
         }
         if use_cached:
           y_test = read_from_csv(gt_csv)
@@ -1709,7 +1767,7 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
               if "gate_s" in p_test:
                 aux_scores["gate_s"] = p_test["gate_s"].cpu().numpy()
 
-          if args.data_set in {"advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base", "advCheX_hyp_grade_stage_embtab_v2lite"}:
+          if args.data_set in {"advCheX_hyp_multi_grade_stage_sep_v1", "advCheX_hyp_multi_grade_stage_v1", "advCheX_hyp_grade_stage_v2", "advCheX_hyp_grade_stage_embtab_base", "advCheX_hyp_grade_stage_embtab_v2lite", "advCheX_hyp_grade_stage_tab_only", "advCheX_hyp_grade_stage_imgemb_only", "advCheX_hyp_grade_stage_simple_concat_fusion"}:
             output_dir = os.path.dirname(output_file)
             val_y_grade = val_y_stage = val_p_grade = val_p_stage = None
             decoder_mode = str(getattr(args, "decodermode", "non")).lower()
@@ -1775,7 +1833,7 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
               loss_w_grade_soft=getattr(args, "loss_w_grade_soft", 0.2),
               loss_w_stage_soft=getattr(args, "loss_w_stage_soft", 0.1),
               loss_w_stage_smooth=getattr(args, "loss_w_stage_smooth", 1.0),
-              dataset_tag=("sep_v1" if args.data_set == "advCheX_hyp_multi_grade_stage_sep_v1" else ("v2lite" if args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite" else ("v2" if args.data_set == "advCheX_hyp_grade_stage_v2" else ("embtab_base" if args.data_set == "advCheX_hyp_grade_stage_embtab_base" else "v1")))),
+              dataset_tag=("sep_v1" if args.data_set == "advCheX_hyp_multi_grade_stage_sep_v1" else ("v2lite" if args.data_set == "advCheX_hyp_grade_stage_embtab_v2lite" else ("v2" if args.data_set == "advCheX_hyp_grade_stage_v2" else ("embtab_base" if args.data_set in {"advCheX_hyp_grade_stage_embtab_base","advCheX_hyp_grade_stage_tab_only","advCheX_hyp_grade_stage_imgemb_only","advCheX_hyp_grade_stage_simple_concat_fusion"} else "v1")))),
               v1_soft_label_mode=getattr(args, "v1_soft_label_mode", "none"),
               grade_soft_scheme=getattr(args, "grade_soft_scheme", "asym_v1"),
               stage_soft_scheme=getattr(args, "stage_soft_scheme", "asym_v1"),
@@ -2069,6 +2127,9 @@ def classification_engine(args, model_path, output_path, diseases, dataset_train
         "advCheX_hyp_grade_stage_v2",
         "advCheX_hyp_grade_stage_embtab_base",
         "advCheX_hyp_grade_stage_embtab_v2lite",
+        "advCheX_hyp_grade_stage_tab_only",
+        "advCheX_hyp_grade_stage_imgemb_only",
+        "advCheX_hyp_grade_stage_simple_concat_fusion",
       }:
         return
 

--- a/Finetuning/main_classification.py
+++ b/Finetuning/main_classification.py
@@ -30,7 +30,8 @@ def get_args_parser():
                       default=14, type="int")
     parser.add_option("--num_class_grade", dest="num_class_grade", help="number of grade ordinal logits", default=3, type="int")
     parser.add_option("--num_class_stage", dest="num_class_stage", help="number of stage ordinal logits", default=2, type="int")
-    parser.add_option("--data_set", dest="data_set", help="ChestXray14|CheXpert|Shenzhen|VinDrCXR|RSNAPneumonia|advCheX|advCheX_binary|advCheX_hyp|advCheX_hyp_multi_level|advCheX_hyp_multi_stage_v1|advCheX_hyp_multi_stage_v2|advCheX_hyp_multi_grade_stage_v1|advCheX_hyp_multi_grade_stage_sep_v1|advCheX_hyp_grade_stage_v2|advCheX_hyp_grade_stage_embtab_base|advCheX_hyp_grade_stage_embtab_v2lite", default="ChestXray14", type="string")
+    parser.add_option("--data_set", dest="data_set", help="ChestXray14|CheXpert|Shenzhen|VinDrCXR|RSNAPneumonia|advCheX|advCheX_binary|advCheX_hyp|advCheX_hyp_multi_level|advCheX_hyp_multi_stage_v1|advCheX_hyp_multi_stage_v2|advCheX_hyp_multi_grade_stage_v1|advCheX_hyp_multi_grade_stage_sep_v1|advCheX_hyp_grade_stage_v2|advCheX_hyp_grade_stage_embtab_base|advCheX_hyp_grade_stage_embtab_v2lite|advCheX_hyp_grade_stage_tab_only|advCheX_hyp_grade_stage_imgemb_only|advCheX_hyp_grade_stage_simple_concat_fusion", default="ChestXray14", type="string")
+    parser.add_option("--tabular_only", dest="tabular_only", default=False, action="store_true")
     parser.add_option("--normalization", dest="normalization", help="how to normalize data (imagenet|chestx-ray)", default="imagenet",
                       type="string")
     parser.add_option("--img_size", dest="img_size", help="resize image resolution", default=256, type="int")
@@ -744,13 +745,14 @@ def main(args):
             augment=build_transform_classification(normalize=args.normalization, mode="test", crop_size=args.input_size, resize=args.img_size))
         classification_engine(args, model_path, output_path, diseases, dataset_train, dataset_val, dataset_test)
 
-    elif args.data_set == "advCheX_hyp_grade_stage_embtab_base":
+    elif args.data_set in {"advCheX_hyp_grade_stage_embtab_base", "advCheX_hyp_grade_stage_tab_only", "advCheX_hyp_grade_stage_imgemb_only", "advCheX_hyp_grade_stage_simple_concat_fusion"}:
         args.num_class_grade = 3
         args.num_class_stage = 2
         args.num_class = args.num_class_grade
         diseases = ["grade", "stage"]
         val_images_root = args.val_data_dir if getattr(args, "val_data_dir", None) else args.data_dir
         need_decoder_val = str(getattr(args, "decodermode", "non")).lower() != "non"
+        load_img_emb = args.data_set != "advCheX_hyp_grade_stage_tab_only"
         if args.mode == "train":
             dataset_train = advCheX_hyp_grade_stage_embtab_base(
                 images_path=args.data_dir,
@@ -758,12 +760,14 @@ def main(args):
                 split="train",
                 tab_norm_stats=None,
                 few_shot=args.few_shot,
+                load_img_emb=load_img_emb,
             )
             dataset_val = advCheX_hyp_grade_stage_embtab_base(
                 images_path=val_images_root,
                 file_path=args.val_list,
                 split="valid",
                 tab_norm_stats=dataset_train.tab_norm_stats,
+                load_img_emb=load_img_emb,
             )
         else:
             dataset_train = None
@@ -773,12 +777,14 @@ def main(args):
                     file_path=args.train_list,
                     split="train",
                     tab_norm_stats=None,
+                    load_img_emb=load_img_emb,
                 )
                 dataset_val = advCheX_hyp_grade_stage_embtab_base(
                     images_path=val_images_root,
                     file_path=args.val_list,
                     split="valid",
                     tab_norm_stats=dataset_val_train.tab_norm_stats,
+                    load_img_emb=load_img_emb,
                 )
             else:
                 dataset_val = None
@@ -792,6 +798,7 @@ def main(args):
                 file_path=args.train_list,
                 split="train",
                 tab_norm_stats=None,
+                load_img_emb=False,
             )
             tab_stats_for_test = dataset_train_for_stats.tab_norm_stats
         dataset_test = advCheX_hyp_grade_stage_embtab_base(
@@ -799,6 +806,7 @@ def main(args):
             file_path=args.test_list,
             split="test",
             tab_norm_stats=tab_stats_for_test,
+            load_img_emb=load_img_emb,
         )
         classification_engine(args, model_path, output_path, diseases, dataset_train, dataset_val, dataset_test)
 

--- a/Finetuning/models.py
+++ b/Finetuning/models.py
@@ -75,6 +75,42 @@ def build_classification_model(args):
             num_class_grade=getattr(args, "num_class_grade", 3),
             num_class_stage=getattr(args, "num_class_stage", 2),
         )
+    if getattr(args, "data_set", "") == "advCheX_hyp_grade_stage_tab_only":
+        return TabularOnlyOrdinalModel(
+            tab_dim=getattr(args, "tab_dim", 5),
+            tab_hidden_dim=getattr(args, "tab_hidden_dim", 32),
+            tab_out_dim=getattr(args, "tab_out_dim", 64),
+            task_hidden_dim=getattr(args, "task_hidden_dim", 128),
+            dropout_tab=getattr(args, "dropout_tab", 0.1),
+            num_class_grade=getattr(args, "num_class_grade", 3),
+            num_class_stage=getattr(args, "num_class_stage", 2),
+        )
+    if getattr(args, "data_set", "") == "advCheX_hyp_grade_stage_imgemb_only":
+        return EmbeddingOnlyOrdinalModel(
+            img_emb_dim=getattr(args, "img_emb_dim", 1376),
+            img_hidden_dim=getattr(args, "img_hidden_dim", 512),
+            img_out_dim=getattr(args, "img_out_dim", 256),
+            task_hidden_dim=getattr(args, "task_hidden_dim", 128),
+            dropout_img=getattr(args, "dropout_img", 0.2),
+            num_class_grade=getattr(args, "num_class_grade", 3),
+            num_class_stage=getattr(args, "num_class_stage", 2),
+        )
+    if getattr(args, "data_set", "") == "advCheX_hyp_grade_stage_simple_concat_fusion":
+        return SimpleConcatFusionOrdinalModel(
+            img_emb_dim=getattr(args, "img_emb_dim", 1376),
+            tab_dim=getattr(args, "tab_dim", 5),
+            img_hidden_dim=getattr(args, "img_hidden_dim", 512),
+            img_out_dim=getattr(args, "img_out_dim", 256),
+            tab_hidden_dim=getattr(args, "tab_hidden_dim", 32),
+            tab_out_dim=getattr(args, "tab_out_dim", 64),
+            fusion_hidden_dim=getattr(args, "fusion_hidden_dim", 192),
+            task_hidden_dim=getattr(args, "task_hidden_dim", 128),
+            dropout_img=getattr(args, "dropout_img", 0.2),
+            dropout_tab=getattr(args, "dropout_tab", 0.1),
+            dropout_fusion=getattr(args, "dropout_fusion", 0.2),
+            num_class_grade=getattr(args, "num_class_grade", 3),
+            num_class_stage=getattr(args, "num_class_stage", 2),
+        )
     if args.pretrained_weights is None or args.pretrained_weights =='':
         print('Loading pretrained {} weights for {} from timm.'.format(args.init, args.model_name))
         if args.model_name.lower() == "vit_base":
@@ -620,6 +656,84 @@ class EmbeddingTabularV2LiteModel(nn.Module):
             "gate_s": gate_s,
             "pG_ctx": pG_ctx,
         }
+
+
+class EmbeddingOnlyOrdinalModel(nn.Module):
+    def __init__(self, img_emb_dim=1376, img_hidden_dim=512, img_out_dim=256, task_hidden_dim=128, dropout_img=0.2, num_class_grade=3, num_class_stage=2):
+        super().__init__()
+        self.img_tower = nn.Sequential(
+            nn.LayerNorm(int(img_emb_dim)),
+            nn.Linear(int(img_emb_dim), int(img_hidden_dim)),
+            nn.GELU(),
+            nn.Dropout(float(dropout_img)),
+            nn.Linear(int(img_hidden_dim), int(img_out_dim)),
+            nn.GELU(),
+        )
+        self.shared = nn.Sequential(nn.Linear(int(img_out_dim), int(task_hidden_dim)), nn.GELU())
+        self.head_grade = nn.Linear(int(task_hidden_dim), int(num_class_grade))
+        self.head_stage = nn.Linear(int(task_hidden_dim), int(num_class_stage))
+
+    def forward(self, x):
+        z = self.img_tower(x["img_emb"])
+        h = self.shared(z)
+        return {"grade_logits": self.head_grade(h), "stage_ind_logits": self.head_stage(h)}
+
+
+class TabularOnlyOrdinalModel(nn.Module):
+    def __init__(self, tab_dim=5, tab_hidden_dim=32, tab_out_dim=64, task_hidden_dim=128, dropout_tab=0.1, num_class_grade=3, num_class_stage=2):
+        super().__init__()
+        self.tab_tower = nn.Sequential(
+            nn.Linear(int(tab_dim), int(tab_hidden_dim)),
+            nn.ReLU(),
+            nn.Dropout(float(dropout_tab)),
+            nn.Linear(int(tab_hidden_dim), int(tab_out_dim)),
+            nn.ReLU(),
+        )
+        self.shared = nn.Sequential(nn.Linear(int(tab_out_dim), int(task_hidden_dim)), nn.GELU())
+        self.head_grade = nn.Linear(int(task_hidden_dim), int(num_class_grade))
+        self.head_stage = nn.Linear(int(task_hidden_dim), int(num_class_stage))
+
+    def forward(self, x):
+        z = self.tab_tower(x["tab"])
+        h = self.shared(z)
+        return {"grade_logits": self.head_grade(h), "stage_ind_logits": self.head_stage(h)}
+
+
+class SimpleConcatFusionOrdinalModel(nn.Module):
+    def __init__(self, img_emb_dim=1376, tab_dim=5, img_hidden_dim=512, img_out_dim=256, tab_hidden_dim=32, tab_out_dim=64,
+                 fusion_hidden_dim=192, task_hidden_dim=128, dropout_img=0.2, dropout_tab=0.1, dropout_fusion=0.2,
+                 num_class_grade=3, num_class_stage=2):
+        super().__init__()
+        self.img_tower = nn.Sequential(
+            nn.LayerNorm(int(img_emb_dim)),
+            nn.Linear(int(img_emb_dim), int(img_hidden_dim)),
+            nn.GELU(),
+            nn.Dropout(float(dropout_img)),
+            nn.Linear(int(img_hidden_dim), int(img_out_dim)),
+            nn.GELU(),
+        )
+        self.tab_tower = nn.Sequential(
+            nn.Linear(int(tab_dim), int(tab_hidden_dim)),
+            nn.ReLU(),
+            nn.Dropout(float(dropout_tab)),
+            nn.Linear(int(tab_hidden_dim), int(tab_out_dim)),
+            nn.ReLU(),
+        )
+        self.fusion = nn.Sequential(
+            nn.Linear(int(img_out_dim + tab_out_dim), int(fusion_hidden_dim)),
+            nn.GELU(),
+            nn.Dropout(float(dropout_fusion)),
+            nn.Linear(int(fusion_hidden_dim), int(task_hidden_dim)),
+            nn.GELU(),
+        )
+        self.head_grade = nn.Linear(int(task_hidden_dim), int(num_class_grade))
+        self.head_stage = nn.Linear(int(task_hidden_dim), int(num_class_stage))
+
+    def forward(self, x):
+        z_img = self.img_tower(x["img_emb"])
+        z_tab = self.tab_tower(x["tab"])
+        h = self.fusion(torch.cat([z_img, z_tab], dim=1))
+        return {"grade_logits": self.head_grade(h), "stage_ind_logits": self.head_stage(h)}
 
 
 

--- a/Finetuning/scripts/baseline_comparison/run_clinical_ml.sh
+++ b/Finetuning/scripts/baseline_comparison/run_clinical_ml.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+MODEL_TYPE="${1:-lr}"
+ROOT="Finetuning/result_tmp/baseline_comparison/clinical_only_${MODEL_TYPE}"
+python Finetuning/baselines/train_clinical_only_ml.py \
+  --train_csv /home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added/train_feat.csv \
+  --valid_csv /home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added/valid_feat.csv \
+  --test_csv /home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added/test_feat.csv \
+  --external_csvs \
+    /home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_handan_testonly/test_feat.csv \
+    /home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_hebei_testonly/test_feat.csv \
+    /home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_hfirstall_testonly/test_feat.csv \
+    /home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_hfirstall_have_bmi_testonly/test_feat.csv \
+    /home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_handan_have_bmi_testonly/test_feat.csv \
+  --external_names handan hebei hfirstALL hfirstALL_have_bmi handan_have_bmi \
+  --model_type "${MODEL_TYPE}" --out_root "${ROOT}"

--- a/Finetuning/scripts/baseline_comparison/test_baseline_multi_cohort.sh
+++ b/Finetuning/scripts/baseline_comparison/test_baseline_multi_cohort.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "${ROOT_DIR}"
+DATASET_NAME="${1:?dataset_name}"; EXP_SUFFIX="${2:?exp_suffix}"; MODEL_NAME="${3:-swin_large_384}"; INIT_NAME="${4:-ark_plus}"
+TRAIN_LIST="/home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added/train_feat.csv"
+VAL_LIST="/home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added/valid_feat.csv"
+VAL_DATA_DIR="/home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added"
+OUTPUTS_DIR="Outputs/Classification/${DATASET_NAME}"
+declare -A COHORTS=(
+  [internal]="/home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added"
+  [handan]="/home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_handan_testonly"
+  [hebei]="/home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_hebei_testonly"
+  [hfirstALL]="/home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_hfirstall_testonly"
+  [hfirstALL_have_bmi]="/home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_hfirstall_have_bmi_testonly"
+  [handan_have_bmi]="/home/pcl/data/lxx/advCheX_Hyp_multi_grade_stage_feat_handan_have_bmi_testonly"
+)
+for combo in non:qwk temp_ev:macro_f1 temp_threshold:composite; do
+  mode="${combo%%:*}"; obj="${combo##*:}"
+  for name in "${!COHORTS[@]}"; do
+    data_dir="${COHORTS[$name]}"
+    CUDA_VISIBLE_DEVICES=0 python main_classification.py --mode test --data_set "${DATASET_NAME}" --data_dir "${data_dir}" \
+      --exp_name "${EXP_SUFFIX}" --train_list "${TRAIN_LIST}" --val_list "${VAL_LIST}" --test_list "${data_dir}/test_feat.csv" \
+      --val_data_dir "${VAL_DATA_DIR}" --model "${MODEL_NAME}" --init "${INIT_NAME}" --batch_size 64 --freeze_encoder False \
+      --ordinal_mode CORN --decodermode "${mode}" --decoder_objective "${obj}" --decoder_bins 101 \
+      --decoder_use_saved_thresholds False --decoder_save_debug True --decoder_keep_raw_metrics True \
+      --temperature_init 1.0 --temperature_min 0.5 --temperature_max 5.0 --temperature_grid_size 91 \
+      --workers 4 --return_path True
+
+    save_dir="Finetuning/result_tmp/baseline_comparison/${DATASET_NAME}/decoder_${mode}_${obj}/${name}"; mkdir -p "${save_dir}"
+    if [[ -d "${OUTPUTS_DIR}" ]]; then
+      find "${OUTPUTS_DIR}" -maxdepth 1 -type f \( -name "*.png" -o -name "*.json" -o -name "*.csv" -o -name "*results.txt" -o -name "result.txt" \) -exec cp -f {} "${save_dir}/" \;
+      [[ -f "${save_dir}/${EXP_SUFFIX}_results.txt" ]] && mv -f "${save_dir}/${EXP_SUFFIX}_results.txt" "${save_dir}/result.txt" || true
+    fi
+    cat > "${save_dir}/run_info.txt" <<EOF
+mode=${mode}
+objective=${obj}
+dataset=${name}
+data_set=${DATASET_NAME}
+exp_name=${EXP_SUFFIX}
+data_dir=${data_dir}
+train_list=${TRAIN_LIST}
+val_list=${VAL_LIST}
+test_list=${data_dir}/test_feat.csv
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+EOF
+  done
+done

--- a/Finetuning/scripts/baseline_comparison/test_clinical_ml_auto.sh
+++ b/Finetuning/scripts/baseline_comparison/test_clinical_ml_auto.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+MODEL_TYPE="${1:-lr}"
+bash Finetuning/scripts/baseline_comparison/run_clinical_ml.sh "${MODEL_TYPE}"

--- a/Finetuning/scripts/baseline_comparison/test_image_only_mlp_auto.sh
+++ b/Finetuning/scripts/baseline_comparison/test_image_only_mlp_auto.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bash Finetuning/scripts/baseline_comparison/test_baseline_multi_cohort.sh advCheX_hyp_grade_stage_imgemb_only _mimic_imgonly_mlp_seed42

--- a/Finetuning/scripts/baseline_comparison/test_simple_concat_fusion_mlp_auto.sh
+++ b/Finetuning/scripts/baseline_comparison/test_simple_concat_fusion_mlp_auto.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bash Finetuning/scripts/baseline_comparison/test_baseline_multi_cohort.sh advCheX_hyp_grade_stage_simple_concat_fusion _mimic_simple_concat_mlp_seed42

--- a/Finetuning/scripts/baseline_comparison/test_tabular_only_mlp_auto.sh
+++ b/Finetuning/scripts/baseline_comparison/test_tabular_only_mlp_auto.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bash Finetuning/scripts/baseline_comparison/test_baseline_multi_cohort.sh advCheX_hyp_grade_stage_tab_only _mimic_tabonly_mlp_seed42

--- a/Finetuning/scripts/baseline_comparison/train_image_only_mlp.sh
+++ b/Finetuning/scripts/baseline_comparison/train_image_only_mlp.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DATA_DIR="/home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added"
+PRETRAIN="./Ark6_swinLarge768_ep50.pth.tar"
+EXP_SUFFIX="_mimic_imgonly_mlp_seed42"
+CUDA_VISIBLE_DEVICES=0,1 python main_classification.py \
+  --mode train --data_set advCheX_hyp_grade_stage_imgemb_only --data_dir "${DATA_DIR}" \
+  --train_list "${DATA_DIR}/train_feat.csv" --val_list "${DATA_DIR}/valid_feat.csv" --test_list "${DATA_DIR}/test_feat.csv" \
+  --model swin_large_384 --init ark_plus --pretrained_weights "${PRETRAIN}" --exp_name "${EXP_SUFFIX}" \
+  --epochs 50 --batch_size 128 --opt adamw --lr 5e-4 --weight-decay 1e-4 --patience 8 --freeze_encoder False \
+  --ordinal_mode CORN --img_emb_dim 1376 --img_hidden_dim 512 --img_out_dim 256 --task_hidden_dim 128 --dropout_img 0.2 \
+  --lambda_cond 0.0 --lambda_joint_soft 0.0 --decodermode non --decoder_objective qwk --skip_test True --workers 4

--- a/Finetuning/scripts/baseline_comparison/train_simple_concat_fusion_mlp.sh
+++ b/Finetuning/scripts/baseline_comparison/train_simple_concat_fusion_mlp.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DATA_DIR="/home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added"
+PRETRAIN="./Ark6_swinLarge768_ep50.pth.tar"
+EXP_SUFFIX="_mimic_simple_concat_mlp_seed42"
+CUDA_VISIBLE_DEVICES=0,1 python main_classification.py \
+  --mode train --data_set advCheX_hyp_grade_stage_simple_concat_fusion --data_dir "${DATA_DIR}" \
+  --train_list "${DATA_DIR}/train_feat.csv" --val_list "${DATA_DIR}/valid_feat.csv" --test_list "${DATA_DIR}/test_feat.csv" \
+  --model swin_large_384 --init ark_plus --pretrained_weights "${PRETRAIN}" --exp_name "${EXP_SUFFIX}" \
+  --epochs 50 --batch_size 128 --opt adamw --lr 5e-4 --weight-decay 1e-4 --patience 8 --freeze_encoder False \
+  --ordinal_mode CORN --img_emb_dim 1376 --tab_dim 5 --img_hidden_dim 512 --img_out_dim 256 --tab_hidden_dim 32 --tab_out_dim 64 \
+  --fusion_hidden_dim 192 --task_hidden_dim 128 --dropout_img 0.2 --dropout_tab 0.1 --dropout_fusion 0.2 \
+  --lambda_cond 0.0 --lambda_joint_soft 0.0 --decodermode non --decoder_objective qwk --skip_test True --workers 4

--- a/Finetuning/scripts/baseline_comparison/train_tabular_only_mlp.sh
+++ b/Finetuning/scripts/baseline_comparison/train_tabular_only_mlp.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DATA_DIR="/home/pcl/data/lxx/mimic_multi_stage_v2_with_ehr_added"
+PRETRAIN="./Ark6_swinLarge768_ep50.pth.tar"
+EXP_SUFFIX="_mimic_tabonly_mlp_seed42"
+CUDA_VISIBLE_DEVICES=0,1 python main_classification.py \
+  --mode train --data_set advCheX_hyp_grade_stage_tab_only --data_dir "${DATA_DIR}" \
+  --train_list "${DATA_DIR}/train_feat.csv" --val_list "${DATA_DIR}/valid_feat.csv" --test_list "${DATA_DIR}/test_feat.csv" \
+  --model swin_large_384 --init ark_plus --pretrained_weights "${PRETRAIN}" --exp_name "${EXP_SUFFIX}" \
+  --epochs 50 --batch_size 128 --opt adamw --lr 5e-4 --weight-decay 1e-4 --patience 8 --freeze_encoder False \
+  --ordinal_mode CORN --tab_dim 5 --tab_hidden_dim 32 --tab_out_dim 64 --task_hidden_dim 128 --dropout_tab 0.1 \
+  --lambda_cond 0.0 --lambda_joint_soft 0.0 --decodermode non --decoder_objective qwk --skip_test True --workers 4


### PR DESCRIPTION
### Motivation

- Provide reproducible baseline comparisons including a traditional clinical ML pipeline and lightweight neural baselines for tabular-only, image-embedding-only and simple fusion experiments. 
- Allow faster tabular-only experiments by avoiding loading image embeddings when not needed and keep evaluation outputs compatible with the existing decoder/result pipeline.

### Description

- Added `Finetuning/baselines/train_clinical_only_ml.py` implementing logistic regression / random forest / LightGBM (with HGB fallback) training, evaluation and richer outputs (`metrics.json`, `predictions.csv`, `result.txt`, `Confmat_*.png`, `invalid_type_hist.png`).
- Added three lightweight model classes and wiring in `Finetuning/models.py`: `TabularOnlyOrdinalModel`, `EmbeddingOnlyOrdinalModel`, and `SimpleConcatFusionOrdinalModel`, and registered them in `build_classification_model` for new dataset modes.
- Extended `advCheX_hyp_grade_stage_embtab_base` in `Finetuning/dataloader.py` with a `load_img_emb` flag and a zero-vector fallback when embeddings are skipped, and updated `main_classification.py` to expose the new dataset names and to control `load_img_emb` during dataset construction.
- Updated `Finetuning/engine.py` to recognize the new multihead dataset modes and to preserve existing decoder/dataflow behavior, added multiple helper/training/test scripts under `Finetuning/scripts/baseline_comparison/`, and recorded the changes in `Finetuning/change_log.md`.

### Testing

- Performed a smoke end-to-end run of `Finetuning/baselines/train_clinical_only_ml.py` on a small sample CSV to verify that `metrics.json`, `predictions.csv`, `result.txt` and the PNG figures are produced; this run succeeded.
- Ran quick instantiation and lightweight `--mode test` checks of `main_classification.py` for the new dataset modes (including `load_img_emb=False`) to confirm dataset loading and model creation for the tabular/image/concat models; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba3203ae88331afb4d228ce9ee544)