### PR TITLE
Harden ordinal evaluation shape checks and prevent 1D squeeze in test aggregation

### DIFF
--- a/CHANGELOG_codex.txt
+++ b/CHANGELOG_codex.txt
@@ -1,3 +1,7 @@
+[2026-05-07] -codex
+Reason: 修复“序数评估输入被挤压后维度语义漂移”导致的评估不稳定问题，保证 tab-only/image-only/simple-concat 与 embtab 系列在同一严格评估口径下运行。
+Changes: 在 `Finetuning/utils.py` 新增 `_validate_ordinal_k`，并在 `evaluate_grade_stage_sep` 入口强制校验 `y_grade[N,3]/y_stage[N,2]/p_ge_grade[N,3]/p_ge_stage[N,2]`；`ordinal_probs_to_class_probs` 仅允许 `K in {2,3}`，遇到非法通道数直接报错而不是隐式落入错误分支；在 `Finetuning/trainer.py::test_classification` 新增 `_ensure_2d_batch_tensor` 并应用到多头测试聚合分支（coarse-fine dict、v2 dict、tuple），防止推理后拼接阶段出现 1D squeeze 引发的后续评估崩溃；不改变 embtab-v2lite/embtab-base/v1/sep/v2 的数据集路由与训练/测试命令接口。
+
 [2026-03-13] -codex
 Reason: 在 sep_v1 + coarse_fine 验证版增加第一轮最小可行的 fine-head soft label/LDL 辅助损失正则，只影响训练端并保持测试/decoder主逻辑稳定。
 Changes: 新增 --fine_soft_label_mode(none|grade_only|grade_and_stage)、--grade_soft_center、--stage_label_smoothing、--loss_w_grade_soft、--loss_w_stage_smooth；仅在 advCheX_hyp_multi_grade_stage_sep_v1 + sep_head_mode=coarse_fine 下生效：grade 分支保持 CORN 主损失并附加 soft CE(LDL)辅助项，stage 分支在 grade_and_stage 模式使用 smoothed BCE target；coarse head结构与loss主逻辑不改；训练日志补充 L_G_CORN/L_G_soft/L_G_total 与 stage smoothing 状态；metrics.json/result.txt 追加 soft-label 配置字段。

--- a/Finetuning/change_log.md
+++ b/Finetuning/change_log.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## 2026-05-07 ordinal evaluation stability + fairness hardening (ABCD)
+
+- Reworked ordinal shape handling to avoid silent semantic drift:
+  - Added `_validate_ordinal_k(...)` to enforce expected ordinal channel count.
+  - `evaluate_grade_stage_sep` now validates:
+    - `y_grade` as `[N,3]`
+    - `y_stage` as `[N,2]`
+    - `p_ge_grade` as `[N,3]`
+    - `p_ge_stage` as `[N,2]`
+- Hardened `ordinal_probs_to_class_probs(...)`:
+  - Explicitly supports only `K=2` (stage) and `K=3` (grade).
+  - Raises clear errors for unexpected `K` instead of falling through and indexing invalid channels.
+- Added test-time aggregation safety in `trainer.test_classification(...)`:
+  - New `_ensure_2d_batch_tensor(...)` ensures per-batch multi-head outputs remain 2D before concat.
+  - Applied to all multi-head test branches (coarse-fine dict, v2 dict, tuple branch), reducing squeeze-related runtime instability for:
+    - tab-only MLP
+    - image-only projector MLP
+    - simple-concat fusion MLP
+    - while preserving existing embtab/v1/v2/sep code paths unless shape is invalid.
+
+Compatibility note:
+- This is a strict validation + robustness update; old modes are not rerouted and their training/testing interfaces stay unchanged.
+
 ## 2026-05-06 baseline comparison extension
 
 - Added three new PyTorch baseline dataset/model routes:

--- a/Finetuning/trainer.py
+++ b/Finetuning/trainer.py
@@ -52,6 +52,16 @@ def _batch_size(samples):
   return int(samples.size(0))
 
 
+def _ensure_2d_batch_tensor(x, name="tensor"):
+  if not torch.is_tensor(x):
+    raise TypeError(f"{name} must be a torch.Tensor, got {type(x)}")
+  if x.dim() == 1:
+    return x.unsqueeze(1)
+  if x.dim() == 2:
+    return x
+  raise ValueError(f"{name} must be 1D or 2D before aggregation, got shape={tuple(x.shape)}")
+
+
 def train_one_epoch(data_loader_train, device,model, criterion, optimizer, epoch):
   batch_time = MetricLogger('Time', ':6.3f')
   losses = MetricLogger('Loss', ':.4e')
@@ -279,6 +289,8 @@ def test_classification(checkpoint, data_loader_test, device, args):
         out_stage = torch.cat([pH, pH * b], dim=1)
         out_grade_mean = out_grade.view(bs, n_crops, -1).mean(1)
         out_stage_mean = out_stage.view(bs, n_crops, -1).mean(1)
+        out_grade_mean = _ensure_2d_batch_tensor(out_grade_mean, "out_grade_mean(anyhtn)")
+        out_stage_mean = _ensure_2d_batch_tensor(out_stage_mean, "out_stage_mean(anyhtn)")
         p_grade_test = torch.cat((p_grade_test, out_grade_mean.data), 0)
         p_stage_test = torch.cat((p_stage_test, out_stage_mean.data), 0)
         p_anyhtn_test = torch.cat((p_anyhtn_test, pH.view(bs, n_crops, -1).mean(1).data), 0)
@@ -299,6 +311,8 @@ def test_classification(checkpoint, data_loader_test, device, args):
         )
         out_grade_mean = raw_grade_ge.view(bs, n_crops, -1).mean(1)
         out_stage_mean = raw_stage_ge.view(bs, n_crops, -1).mean(1)
+        out_grade_mean = _ensure_2d_batch_tensor(out_grade_mean, "out_grade_mean(v2)")
+        out_stage_mean = _ensure_2d_batch_tensor(out_stage_mean, "out_stage_mean(v2)")
         p_grade_test = torch.cat((p_grade_test, out_grade_mean.data), 0)
         p_stage_test = torch.cat((p_stage_test, out_stage_mean.data), 0)
         q1_test = torch.cat((q1_test, joint["q1"].view(bs, n_crops, -1).mean(1).data), 0)
@@ -321,6 +335,8 @@ def test_classification(checkpoint, data_loader_test, device, args):
           out_stage = torch.sigmoid(out_stage)
         out_grade_mean = out_grade.view(bs, n_crops, -1).mean(1)
         out_stage_mean = out_stage.view(bs, n_crops, -1).mean(1)
+        out_grade_mean = _ensure_2d_batch_tensor(out_grade_mean, "out_grade_mean(tuple)")
+        out_stage_mean = _ensure_2d_batch_tensor(out_stage_mean, "out_stage_mean(tuple)")
         p_grade_test = torch.cat((p_grade_test, out_grade_mean.data), 0)
         p_stage_test = torch.cat((p_stage_test, out_stage_mean.data), 0)
       else:

--- a/Finetuning/utils.py
+++ b/Finetuning/utils.py
@@ -490,19 +490,48 @@ def ordinal_logits_to_probs(logits):
     return 1.0 / (1.0 + np.exp(-logits))
 
 
+def _ensure_ordinal_2d(p_ge, name="p_ge"):
+    """
+    Ensure ordinal probability tensor has shape [N, K].
+    Accepts:
+      - [N, K] (as-is)
+      - [N] -> [N, 1] (defensive fallback)
+    """
+    arr = np.asarray(p_ge)
+    if arr.ndim == 2:
+        return arr
+    if arr.ndim == 1:
+        return arr.reshape(-1, 1)
+    raise ValueError(f"{name} must be 1D or 2D array-like, got shape={arr.shape}")
+
+
+def _validate_ordinal_k(p_ge, expected_k, name="p_ge"):
+    arr = _ensure_ordinal_2d(p_ge, name=name)
+    if arr.shape[1] != int(expected_k):
+        raise ValueError(
+            f"{name} expected shape [N, {int(expected_k)}], got {arr.shape}. "
+            f"This usually indicates upstream output squeeze or wrong head dimension."
+        )
+    return arr
+
+
 def ordinal_probs_to_class_probs(p_ge):
-    p_ge = np.asarray(p_ge)
+    p_ge = _ensure_ordinal_2d(p_ge, name="p_ge")
     k = p_ge.shape[1]
     if k == 2:
         p0 = 1 - p_ge[:, 0]
         p1 = np.clip(p_ge[:, 0] - p_ge[:, 1], 0, 1)
         p2 = np.clip(p_ge[:, 1], 0, 1)
         return np.stack([p0, p1, p2], axis=1)
-    p0 = 1 - p_ge[:, 0]
-    p1 = np.clip(p_ge[:, 0] - p_ge[:, 1], 0, 1)
-    p2 = np.clip(p_ge[:, 1] - p_ge[:, 2], 0, 1)
-    p3 = np.clip(p_ge[:, 2], 0, 1)
-    return np.stack([p0, p1, p2, p3], axis=1)
+    if k == 3:
+        p0 = 1 - p_ge[:, 0]
+        p1 = np.clip(p_ge[:, 0] - p_ge[:, 1], 0, 1)
+        p2 = np.clip(p_ge[:, 1] - p_ge[:, 2], 0, 1)
+        p3 = np.clip(p_ge[:, 2], 0, 1)
+        return np.stack([p0, p1, p2, p3], axis=1)
+    raise ValueError(
+        f"ordinal_probs_to_class_probs only supports K in {{2, 3}}, got K={k} with shape={p_ge.shape}"
+    )
 
 
 def corn_marginal_ge_probs(q):
@@ -1195,8 +1224,10 @@ def evaluate_grade_stage_sep(y_grade, y_stage, p_ge_grade, p_ge_stage, output_di
                              lambda_incomp=0.0, lambda_joint=0.0, joint_gate="htn_only", joint_detach="both", incomp_mode="mask_sum"):
     y_grade = np.asarray(y_grade)
     y_stage = np.asarray(y_stage)
-    p_ge_grade = np.asarray(p_ge_grade)
-    p_ge_stage = np.asarray(p_ge_stage)
+    y_grade = _validate_ordinal_k(y_grade, 3, name="y_grade")
+    y_stage = _validate_ordinal_k(y_stage, 2, name="y_stage")
+    p_ge_grade = _validate_ordinal_k(p_ge_grade, 3, name="p_ge_grade")
+    p_ge_stage = _validate_ordinal_k(p_ge_stage, 2, name="p_ge_stage")
     grades_true = np.array([ordinal_targets_to_grade(row) for row in y_grade])
     stages_true = np.array([ordinal_targets_to_grade(row) for row in y_stage])
     pG = ordinal_probs_to_class_probs(p_ge_grade)


### PR DESCRIPTION
### Motivation

- Prevent silent dimension/semantic drift in ordinal outputs that caused unstable evaluation and downstream indexing errors during test/decoding. 
- Avoid runtime crashes in `test_classification` caused by 1D tensors produced after inference being concatenated with 2D batches. 
- Make failures explicit when ordinal head channel counts differ from expected (reduce silent fallthrough into wrong class-prob branches).

### Description

- Added `_ensure_ordinal_2d(...)` and `_validate_ordinal_k(...)` in `Finetuning/utils.py` to defensively ensure ordinal arrays are 1D/2D and have the expected channel count.  
- Changed `evaluate_grade_stage_sep(...)` to call `_validate_ordinal_k(...)` for `y_grade`, `y_stage`, `p_ge_grade`, and `p_ge_stage` so invalid shapes raise clear errors early.  
- Restricted `ordinal_probs_to_class_probs(...)` to explicitly support only `K=2` and `K=3` and raise a `ValueError` for other `K` values instead of silently falling through.  
- Added `_ensure_2d_batch_tensor(...)` in `Finetuning/trainer.py` and applied it to all multi-head test aggregation branches (coarse-fine dict, v2 dict, tuple) to ensure per-batch outputs are 2D before `torch.cat`, preventing squeeze-induced 1D concatenation errors.  
- Updated changelogs (`CHANGELOG_codex.txt` and `Finetuning/change_log.md`) describing the ordinal evaluation stability and the test-time aggregation hardening and noting compatibility/behavioral intent.

### Testing

- Ran the repository's automated test suite and existing Finetuning evaluation smoke tests, and they completed without failures.  
- Executed targeted smoke tests of `evaluate_grade_stage_sep` with synthetic ordinal arrays to confirm shape validation raises on invalid channel counts and accepts valid `K=2/3` inputs.  
- Performed inference-level smoke tests invoking `test_classification` on minimal synthetic batches to verify that aggregation no longer crashes when heads produce squeezed 1D outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc788dd4b48331824e57c406b9fc0a)